### PR TITLE
Migrate dependencies

### DIFF
--- a/lib/pages/home/base/widgets/app_bar.dart
+++ b/lib/pages/home/base/widgets/app_bar.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:share/share.dart';
+import 'package:share_plus/share_plus.dart';
 
 import '../../../../routes/app_pages.dart';
 

--- a/lib/utils/ffmpeg_api_wrapper.dart
+++ b/lib/utils/ffmpeg_api_wrapper.dart
@@ -1,158 +1,123 @@
-/*
- * Copyright (c) 2020 Taner Sener
- *
- * This file is part of FlutterFFmpeg.
- *
- * FlutterFFmpeg is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * FlutterFFmpeg is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with FlutterFFmpeg.  If not, see <http://www.gnu.org/licenses/>.
- */
-
 import 'dart:async';
 
-import 'package:flutter_ffmpeg/ffmpeg_execution.dart';
-import 'package:flutter_ffmpeg/flutter_ffmpeg.dart';
-import 'package:flutter_ffmpeg/media_information.dart';
-import 'package:flutter_ffmpeg/statistics.dart';
-
-final FlutterFFmpegConfig _flutterFFmpegConfig = FlutterFFmpegConfig();
-final FlutterFFmpeg _flutterFFmpeg = FlutterFFmpeg();
-final FlutterFFprobe _flutterFFprobe = FlutterFFprobe();
+import 'package:ffmpeg_kit_flutter/ffmpeg_kit.dart';
+import 'package:ffmpeg_kit_flutter/ffmpeg_kit_config.dart';
+import 'package:ffmpeg_kit_flutter/ffmpeg_session.dart';
+import 'package:ffmpeg_kit_flutter/ffprobe_kit.dart';
+import 'package:ffmpeg_kit_flutter/ffprobe_session.dart';
+import 'package:ffmpeg_kit_flutter/log_callback.dart';
+import 'package:ffmpeg_kit_flutter/media_information_session.dart';
+import 'package:ffmpeg_kit_flutter/session.dart';
+import 'package:ffmpeg_kit_flutter/statistics.dart';
+import 'package:ffmpeg_kit_flutter/statistics_callback.dart';
 
 void enableLogCallback(LogCallback callback) {
-  _flutterFFmpegConfig.enableLogCallback(callback);
+  FFmpegKitConfig.enableLogCallback(callback);
 }
 
 void enableStatisticsCallback(StatisticsCallback callback) {
-  _flutterFFmpegConfig.enableStatisticsCallback(callback);
+  FFmpegKitConfig.enableStatisticsCallback(callback);
 }
 
-Future<String> getFFmpegVersion() async {
-  return await _flutterFFmpegConfig.getFFmpegVersion();
+Future<String?> getFFmpegVersion() async {
+  return await FFmpegKitConfig.getFFmpegVersion();
 }
 
-Future<String> getPlatform() async {
-  return await _flutterFFmpegConfig.getPlatform();
+Future<String?> getPlatform() async {
+  return await FFmpegKitConfig.getPlatform();
 }
 
-Future<int> executeFFmpegWithArguments(List<String> arguments) async {
-  return await _flutterFFmpeg.executeWithArguments(arguments);
+Future<FFmpegSession> executeFFmpegWithArguments(List<String> arguments) async {
+  return await FFmpegKit.executeWithArguments(arguments);
 }
 
-Future<int> executeFFmpeg(String command) async {
-  return await _flutterFFmpeg.execute(command);
+Future<FFmpegSession> executeFFmpeg(String command) async {
+  return await FFmpegKit.execute(command);
 }
 
-Future<int> executeAsyncFFmpeg(
-    String command, ExecuteCallback executeCallback) async {
-  return await _flutterFFmpeg.executeAsync(command, executeCallback);
+Future<FFmpegSession> executeAsyncFFmpeg(
+    String command, void Function(FFmpegSession)? completeCallback) async {
+  return await FFmpegKit.executeAsync(command, completeCallback);
 }
 
-Future<int> executeFFprobeWithArguments(List<String> arguments) async {
-  return await _flutterFFprobe.executeWithArguments(arguments);
+Future<FFprobeSession> executeFFprobeWithArguments(List<String> arguments) async {
+  return await FFprobeKit.executeWithArguments(arguments);
 }
 
-Future<int> executeFFprobe(String command) async {
-  return await _flutterFFprobe.execute(command);
+Future<FFprobeSession> executeFFprobe(String command) async {
+  return await FFprobeKit.execute(command);
 }
 
 Future<void> cancel() async {
-  return await _flutterFFmpeg.cancel();
+  return await FFmpegKit.cancel();
 }
 
 Future<void> cancelExecution(int executionId) async {
-  return await _flutterFFmpeg.cancelExecution(executionId);
+  return await FFmpegKit.cancel(executionId);
 }
 
 Future<void> disableRedirection() async {
-  return await _flutterFFmpegConfig.disableRedirection();
+  return await FFmpegKitConfig.disableRedirection();
 }
 
-Future<int> getLogLevel() async {
-  return await _flutterFFmpegConfig.getLogLevel();
-}
+int getLogLevel() => FFmpegKitConfig.getLogLevel();
 
 Future<void> setLogLevel(int logLevel) async {
-  return await _flutterFFmpegConfig.setLogLevel(logLevel);
+  return await FFmpegKitConfig.setLogLevel(logLevel);
 }
 
 Future<void> enableLogs() async {
-  return await _flutterFFmpegConfig.enableLogs();
+  return await FFmpegKitConfig.enableLogs();
 }
 
 Future<void> disableLogs() async {
-  return await _flutterFFmpegConfig.disableLogs();
+  return await FFmpegKitConfig.disableLogs();
 }
 
 Future<void> enableStatistics() async {
-  return await _flutterFFmpegConfig.enableStatistics();
+  return await FFmpegKitConfig.enableStatistics();
 }
 
 Future<void> disableStatistics() async {
-  return await _flutterFFmpegConfig.disableStatistics();
+  return await FFmpegKitConfig.disableStatistics();
 }
 
-Future<Statistics> getLastReceivedStatistics() async {
-  return await _flutterFFmpegConfig.getLastReceivedStatistics();
-}
-
-Future<void> resetStatistics() async {
-  return await _flutterFFmpegConfig.resetStatistics();
+Future<Statistics?> getLastReceivedStatistics() async {
+  return FFmpegSession().getLastReceivedStatistics();
 }
 
 Future<void> setFontconfigConfigurationPath(String path) async {
-  return await _flutterFFmpegConfig.setFontconfigConfigurationPath(path);
+  return await FFmpegKitConfig.setFontconfigConfigurationPath(path);
 }
 
-Future<void> setFontDirectory(
-    String fontDirectory, Map<String, String> fontNameMap) async {
-  return await _flutterFFmpegConfig.setFontDirectory(
-      fontDirectory, fontNameMap);
+Future<void> setFontDirectory(String fontDirectory, Map<String, String> fontNameMap) async {
+  return await FFmpegKitConfig.setFontDirectory(fontDirectory, fontNameMap);
 }
 
-Future<String> getPackageName() async {
-  return await _flutterFFmpegConfig.getPackageName();
+Future<Session?> getLastReturnCode() async {
+  return await FFmpegKitConfig.getLastCompletedSession();
 }
 
-Future<List<dynamic>> getExternalLibraries() async {
-  return await _flutterFFmpegConfig.getExternalLibraries();
+Future<Session?> getLastCommandOutput() async {
+  return await FFmpegKitConfig.getLastSession();
 }
 
-Future<int> getLastReturnCode() async {
-  return await _flutterFFmpegConfig.getLastReturnCode();
+Future<MediaInformationSession> getMediaInformation(String path) async {
+  return await FFprobeKit.getMediaInformation(path);
 }
 
-Future<String> getLastCommandOutput() async {
-  return await _flutterFFmpegConfig.getLastCommandOutput();
+Future<String?> registerNewFFmpegPipe() async {
+  return await FFmpegKitConfig.registerNewFFmpegPipe();
 }
 
-Future<MediaInformation> getMediaInformation(String path) async {
-  return await _flutterFFprobe.getMediaInformation(path);
+Future<void> setEnvironmentVariable(String variableName, String variableValue) async {
+  return await FFmpegKitConfig.setEnvironmentVariable(variableName, variableValue);
 }
 
-Future<String> registerNewFFmpegPipe() async {
-  return await _flutterFFmpegConfig.registerNewFFmpegPipe();
-}
-
-Future<void> setEnvironmentVariable(
-    String variableName, String variableValue) async {
-  return await _flutterFFmpegConfig.setEnvironmentVariable(
-      variableName, variableValue);
-}
-
-Future<List<FFmpegExecution>> listFFmpegExecutions() async {
-  return await _flutterFFmpeg.listExecutions();
+Future<List<FFmpegSession>> listFFmpegSessions() async {
+  return await FFmpegKit.listSessions();
 }
 
 List<String>? parseArguments(command) {
-  return FlutterFFmpeg.parseArguments(command);
+  return FFmpegKitConfig.parseArguments(command);
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -129,13 +129,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
-  fijkplayer:
-    dependency: transitive
+  ffmpeg_kit_flutter:
+    dependency: "direct main"
     description:
-      name: fijkplayer
+      name: ffmpeg_kit_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.8"
+    version: "5.1.0"
+  ffmpeg_kit_flutter_platform_interface:
+    dependency: transitive
+    description:
+      name: ffmpeg_kit_flutter_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.1"
   file:
     dependency: transitive
     description:
@@ -155,20 +162,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.3"
-  flutter_ffmpeg:
-    dependency: "direct main"
-    description:
-      name: flutter_ffmpeg
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.4.2"
-  flutter_ffmpeg_fijkplayer:
-    dependency: "direct main"
-    description:
-      name: flutter_ffmpeg_fijkplayer
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.0.3"
   flutter_local_notifications:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -87,6 +87,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.3.3+2"
+  crypto:
+    dependency: transitive
+    description:
+      name: crypto
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.2"
   csslib:
     dependency: transitive
     description:
@@ -100,7 +107,7 @@ packages:
       name: dbus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.8"
   dots_indicator:
     dependency: transitive
     description:
@@ -121,7 +128,14 @@ packages:
       name: ffi
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.1"
+    version: "2.0.1"
+  fijkplayer:
+    dependency: transitive
+    description:
+      name: fijkplayer
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.8.8"
   file:
     dependency: transitive
     description:
@@ -148,13 +162,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.4.2"
+  flutter_ffmpeg_fijkplayer:
+    dependency: "direct main"
+    description:
+      name: flutter_ffmpeg_fijkplayer
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.3"
   flutter_local_notifications:
     dependency: "direct main"
     description:
       name: flutter_local_notifications
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "12.0.0"
+    version: "12.0.4"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
@@ -213,7 +234,7 @@ packages:
       name: group_radio_button
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   html:
     dependency: transitive
     description:
@@ -241,7 +262,7 @@ packages:
       name: introduction_screen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.2"
+    version: "3.1.1"
   js:
     dependency: transitive
     description:
@@ -301,10 +322,12 @@ packages:
   open_file:
     dependency: "direct main"
     description:
-      name: open_file
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.2.1"
+      path: "."
+      ref: fbf68e4
+      resolved-ref: fbf68e4bb5cb3e262d8f8ebe10b2f8449ff8e030
+      url: "https://github.com/crazecoder/open_file.git"
+    source: git
+    version: "3.2.2"
   path:
     dependency: transitive
     description:
@@ -360,7 +383,7 @@ packages:
       name: path_provider_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.7"
+    version: "2.1.3"
   pedantic:
     dependency: transitive
     description:
@@ -374,21 +397,21 @@ packages:
       name: permission_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "10.1.0"
+    version: "10.2.0"
   permission_handler_android:
     dependency: transitive
     description:
       name: permission_handler_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "10.1.0"
+    version: "10.2.0"
   permission_handler_apple:
     dependency: transitive
     description:
       name: permission_handler_apple
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.0.6"
+    version: "9.0.7"
   permission_handler_platform_interface:
     dependency: transitive
     description:
@@ -402,7 +425,7 @@ packages:
       name: permission_handler_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.1"
+    version: "0.1.2"
   petitparser:
     dependency: transitive
     description:
@@ -452,13 +475,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.3.1"
-  share:
+  share_plus:
     dependency: "direct main"
     description:
-      name: share
+      name: share_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4"
+    version: "6.3.0"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.2.0"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -612,7 +642,7 @@ packages:
       name: url_launcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.6"
+    version: "6.1.7"
   url_launcher_android:
     dependency: transitive
     description:
@@ -662,6 +692,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.1"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.7"
   vector_math:
     dependency: transitive
     description:
@@ -675,7 +712,7 @@ packages:
       name: video_player
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.7"
+    version: "2.4.9"
   video_player_android:
     dependency: transitive
     description:
@@ -710,7 +747,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "3.1.2"
   xdg_directories:
     dependency: transitive
     description:
@@ -727,4 +764,4 @@ packages:
     version: "6.1.0"
 sdks:
   dart: ">=2.18.2 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,11 +15,10 @@ dependencies:
     git:
       url: https://github.com/KyleKun/plugins.git
       path: packages/camera/camera/
+  ffmpeg_kit_flutter: ^5.1.0
   flutter:
     sdk: flutter
   flutter_colorpicker: ^1.0.3
-  flutter_ffmpeg: null
-  flutter_ffmpeg_fijkplayer: ^0.0.3
   flutter_local_notifications: ^12.0.4
   fluttertoast: ^8.1.1
   get: ^4.6.5
@@ -29,7 +28,7 @@ dependencies:
   open_file:
     git:
       url: https://github.com/crazecoder/open_file.git
-      ref: fbf68e4 # github commit reference
+      ref: fbf68e4
   path_provider: ^2.0.11
   permission_handler: ^10.2.0
   rive: ^0.9.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,52 +1,55 @@
 name: one_second_diary
 description: Record one second of your day, everyday.
 
-publish_to: 'none'
+publish_to: "none"
 
 version: 1.1.3+7
 
 environment:
-  sdk: '>=2.18.2 <3.0.0'
+  sdk: ">=2.18.2 <3.0.0"
 
 dependencies:
-  about: null
-  avatar_glow: null
+  about: ^2.1.1
+  avatar_glow: ^2.0.2
   camera:
     git:
       url: https://github.com/KyleKun/plugins.git
       path: packages/camera/camera/
   flutter:
     sdk: flutter
-  flutter_colorpicker: null
+  flutter_colorpicker: ^1.0.3
   flutter_ffmpeg: null
-  flutter_local_notifications: null
+  flutter_ffmpeg_fijkplayer: ^0.0.3
+  flutter_local_notifications: ^12.0.4
   fluttertoast: ^8.1.1
-  get: null
-  group_radio_button: null
-  introduction_screen: null
-  native_device_orientation: null
-  open_file: null
-  path_provider: null
-  permission_handler: null
-  rive: null
-  salomon_bottom_bar: null
-  share: null
-  shared_preferences: null
+  get: ^4.6.5
+  group_radio_button: ^1.3.0
+  introduction_screen: ^3.1.1
+  native_device_orientation: ^1.1.4
+  open_file:
+    git:
+      url: https://github.com/crazecoder/open_file.git
+      ref: fbf68e4 # github commit reference
+  path_provider: ^2.0.11
+  permission_handler: ^10.2.0
+  rive: ^0.9.1
+  salomon_bottom_bar: ^3.3.1
+  share_plus: ^6.3.0
+  shared_preferences: ^2.0.15
   tapioca:
     git:
       url: https://github.com/daoxve/tapioca.git
       ref: android-dependency-patch
-  timer_builder: null
-  timezone: null
-  url_launcher: null
-  video_player: null
+  timer_builder: ^2.0.0
+  timezone: ^0.9.0
+  url_launcher: ^6.1.7
+  video_player: ^2.4.9
 #logger:
 dev_dependencies:
   flutter_test:
     sdk: flutter
 
 flutter:
-
   uses-material-design: true
 
   assets:


### PR DESCRIPTION
This PR will be used in upcoming changes.

The current changes included in the PR are in summary:
- Switch to manual dependency tracking to prevent package version inconsistencies, breaking changes, and constraint conflicts.
- Migrate from the deprecated `flutter_ffmpeg` to the successor `ffmpeg_kit_flutter` package
- Migrate from the deprecated `share` package to the successor `share_plus` package
- Migrate `ffmpeg_api_wrapper.dart` to use the new `ffmpeg_kit_flutter` API using the [official guide](https://github.com/tanersener/ffmpeg-kit/wiki/Migrating-From-FlutterFFmpeg)