### PR TITLE
Calendar editor + several improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
-## v2.0 - xx/2022
-- Added Chinese, German and French localization
+## v1.5 - 01/2023
+- Added subtitles feature
+- Added Calendar page
+- Added Edit Subtitles and Add Video options in Calendar page
+- Added automatic and manual geotagging in recording
+- Added options to create a movie by period or only with selected videos
+- Added option to schedule notifications time
+- Added Chinese, Deutsch, Indonesian, and French localization
+- Fixed issues where video recording could not be saved
 
 ## v1.1 - 05/2021
 - Added feature to receive daily notifications

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,6 +7,9 @@
 - Atticdev (@atticdev)
 - Ardin Biganiro (@ardinbig)
 - Alexander ADAM (@alexanderadam)
+- Bagas Wastu (@bagaswastu)
+- Harry Schiller (@waitingwittykitty)
+- David Coker (@daoxve)
 
 ## Testers & Feedback
 - Augusto Vesco
@@ -20,3 +23,4 @@
 - 陈浮生 (Dilql) - Chinese
 - Ardin Biganiro - French
 - Alexander ADAM - German
+- Bagas Wastu - Indonesian

--- a/lib/lang/de.dart
+++ b/lib/lang/de.dart
@@ -7,7 +7,7 @@ const Map<String, String> de = {
       'Vielen Dank!\n\nWenn Du die App unterstützen möchtest,\nfreuen wir uns auf Deine Spende ^^',
   'donationPageTitle': 'App-Entwicklung unterstützen',
   'about': 'Über die App',
-  'appVersion': 'Version 1.1',
+  'appVersion': 'Version 1.5',
   'record': 'Aufnehmen',
   'createMovie': 'Film erstellen',
   'settings': 'Einstellungen',
@@ -93,4 +93,9 @@ const Map<String, String> de = {
   'enterSubtitles': 'Untertitel eingeben',
   'totalSelected': 'Gesamt ausgewählt: ',
   'selectVideos': 'Videos auswählen',
+  'editSubtitles': 'Untertitel\nbearbeiten',
+  'noVideoRecorded': 'Kein Video aufgenommen',
+  'subtitles': 'Untertitel',
+  'addVideo': 'Video hinzufügen',
+  'calendar': 'Kalender',
 };

--- a/lib/lang/en.dart
+++ b/lib/lang/en.dart
@@ -7,7 +7,7 @@ const Map<String, String> en = {
       'Thank you so much for using the app!\n\nIf you wish to support the development,\nfeel free to make a donation ^^',
   'donationPageTitle': 'Support app development',
   'about': 'About',
-  'appVersion': 'Version 1.1',
+  'appVersion': 'Version 1.5',
   'record': 'Record',
   'createMovie': 'Create movie',
   'settings': 'Settings',
@@ -94,4 +94,9 @@ const Map<String, String> en = {
   'enterSubtitles': 'Enter subtitles',
   'totalSelected': 'Total Selected: ',
   'selectVideos': 'Select videos',
+  'editSubtitles': 'Edit\nsubtitles',
+  'noVideoRecorded': 'No video recorded',
+  'subtitles': 'Subtitles',
+  'addVideo': 'Add video',
+  'calendar': 'Calendar',
 };

--- a/lib/lang/es.dart
+++ b/lib/lang/es.dart
@@ -7,7 +7,7 @@ const Map<String, String> es = {
       '¡Muchas gracias por usar la aplicación!\n\Si deseas ayudar al desarrollo y contribuir para seguir mejorando nuestros servidores, \napóyanos con una donación ^^.',
   'donationPageTitle': '¡Apóyanos!',
   'about': 'Acerca de',
-  'appVersion': 'Versión 1.1',
+  'appVersion': 'Versión 1.5',
   'record': 'Grabar',
   'createMovie': 'Crear película',
   'settings': 'Ajustes',
@@ -93,4 +93,9 @@ const Map<String, String> es = {
   'enterSubtitles': 'Introducir subtítulos',
   'totalSelected': 'Total seleccionado: ',
   'selectVideos': 'Seleccionar videos',
+  'editSubtitles': 'Editar\nsubtítulos',
+  'noVideoRecorded': 'No se ha grabado ningún video',
+  'subtitles': 'Subtítulos',
+  'addVideo': 'Agregar video',
+  'calendar': 'Calendario',
 };

--- a/lib/lang/fr.dart
+++ b/lib/lang/fr.dart
@@ -7,7 +7,7 @@ const Map<String, String> fr = {
       "Merci beaucoup d'utiliser l'application !\n\nSi vous souhaitez soutenir le développement,\nn'hésitez pas à faire un don ^^",
   'donationPageTitle': 'Soutenir le développement',
   'about': 'À propos',
-  'appVersion': 'Version 1.1',
+  'appVersion': 'Version 1.5',
   'record': 'Enregistrement',
   'createMovie': 'Créer un film',
   'settings': 'Paramètres',
@@ -95,4 +95,9 @@ const Map<String, String> fr = {
   'enterSubtitles': 'Entrer le sous-titre',
   'totalSelected': 'Total sélectionné: ',
   'selectVideos': 'Sélectionnez les vidéos',
+  'editSubtitles': 'Editer les\nsous-titres',
+  'noVideoRecorded': 'Aucune vidéo enregistrée',
+  'subtitles': 'Sous-titres',
+  'addVideo': 'Ajouter une vidéo',
+  'calendar': 'Calendrier',
 };

--- a/lib/lang/id.dart
+++ b/lib/lang/id.dart
@@ -7,7 +7,7 @@ const Map<String, String> id = {
       'Terima kasih sudah menggunakan aplikasi ini!\n\nJika Anda ingin mendukung pembuatan aplikasi ini, jangan sungkan untuk berdonasi^^.',
   'donationPageTitle': 'Dukung pembuatan aplikasi',
   'about': 'Tentang',
-  'appVersion': 'Versi 1.1',
+  'appVersion': 'Versi 1.5',
   'record': 'Rekam',
   'createMovie': 'Buat video',
   'settings': 'Pengaturan',
@@ -94,4 +94,9 @@ const Map<String, String> id = {
   'enterSubtitles': 'Masukkan subjudul',
   'totalSelected': 'Total dipilih: ',
   'selectVideos': 'Pilih video',
+  'editSubtitles': 'Ubah\nsubjudul',
+  'noVideoRecorded': 'Tidak ada video yang direkam',
+  'subtitles': 'Subjudul',
+  'addVideo': 'Tambah video',
+  'calendar': 'Kalender',
 };

--- a/lib/lang/pt.dart
+++ b/lib/lang/pt.dart
@@ -7,7 +7,7 @@ const Map<String, String> pt = {
       'Muito obrigado por usar o app!\n\nSe desejar apoiar o desenvolvimento, sinta-se livre para fazer uma doação ^^',
   'donationPageTitle': 'Apoiar o desenvolvimento',
   'about': 'Sobre',
-  'appVersion': 'Versão 1.1',
+  'appVersion': 'Versão 1.5',
   'record': 'Gravar',
   'createMovie': 'Criar filme',
   'settings': 'Configurações',
@@ -93,4 +93,9 @@ const Map<String, String> pt = {
   'enterSubtitles': 'Digite uma legenda',
   'totalSelected': 'Total selecionado: ',
   'selectVideos': 'Escolha os vídeos',
+  'editSubtitles': 'Editar\nlegendas',
+  'noVideoRecorded': 'Nenhum vídeo gravado',
+  'subtitles': 'Legendas',
+  'addVideo': 'Adicionar vídeo',
+  'calendar': 'Calendário',
 };

--- a/lib/lang/zh.dart
+++ b/lib/lang/zh.dart
@@ -6,7 +6,7 @@ const Map<String, String> zh = {
   'donateMsg': '非常感谢您使用该应用程序！如果你想支持开发，欢迎您随时捐款 ^^',
   'donationPageTitle': '支持应用开发',
   'about': '关于',
-  'appVersion': '版本信息 1.1',
+  'appVersion': '版本信息 1.5',
   'record': '记录',
   'createMovie': '创建电影',
   'settings': '设置',
@@ -87,4 +87,9 @@ const Map<String, String> zh = {
   'enterSubtitles': '输入字幕',
   'totalSelected': '总选定: ',
   'selectVideos': '选择视频',
+  'editSubtitles': '编辑字幕',
+  'noVideoRecorded': '没有视频被记录',
+  'subtitles': '字幕',
+  'addVideo': '添加视频',
+  'calendar': '日历',
 };

--- a/lib/pages/home/base/home_page.dart
+++ b/lib/pages/home/base/home_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
 import '../../../controllers/bottom_app_bar_index_controller.dart';
+import '../calendar_editor/calendar_editor_page.dart';
 import '../create_movie/create_movie_screen.dart';
 import '../daily_entry/daily_entry_page.dart';
 import '../settings/settings_page.dart';
@@ -29,8 +30,10 @@ class HomePage extends GetView<BottomAppBarIndexController> {
       case 0:
         return DailyEntryPage();
       case 1:
-        return CreateMoviePage();
+        return const CalendarEditorPage();
       case 2:
+        return CreateMoviePage();
+      case 3:
         return SettingPage();
       default:
         return DailyEntryPage();

--- a/lib/pages/home/base/widgets/bottom_app_bar.dart
+++ b/lib/pages/home/base/widgets/bottom_app_bar.dart
@@ -37,6 +37,11 @@ class CustomBottomAppBar extends GetView<BottomAppBarIndexController> {
               color: AppColors.green,
             ),
             _bottomBarItem(
+              icon: Icons.calendar_today_outlined,
+              title: 'createMovie'.tr,
+              color: AppColors.yellow,
+            ),
+            _bottomBarItem(
               icon: Icons.movie_filter_outlined,
               title: 'createMovie'.tr,
               color: AppColors.mainColor,

--- a/lib/pages/home/base/widgets/bottom_app_bar.dart
+++ b/lib/pages/home/base/widgets/bottom_app_bar.dart
@@ -37,8 +37,8 @@ class CustomBottomAppBar extends GetView<BottomAppBarIndexController> {
               color: AppColors.green,
             ),
             _bottomBarItem(
-              icon: Icons.calendar_today_outlined,
-              title: 'createMovie'.tr,
+              icon: Icons.calendar_month_outlined,
+              title: 'calendar'.tr,
               color: AppColors.yellow,
             ),
             _bottomBarItem(

--- a/lib/pages/home/calendar_editor/calendar_editor_page.dart
+++ b/lib/pages/home/calendar_editor/calendar_editor_page.dart
@@ -1,0 +1,264 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_calendar_carousel/classes/event.dart';
+import 'package:flutter_calendar_carousel/flutter_calendar_carousel.dart'
+    show CalendarCarousel;
+import 'package:get/get.dart';
+import 'package:video_thumbnail/video_thumbnail.dart';
+
+import '../../../utils/date_format_utils.dart';
+import '../../../utils/theme.dart';
+import '../../../utils/utils.dart';
+
+class CalendarEditorPage extends StatefulWidget {
+  const CalendarEditorPage({super.key});
+
+  @override
+  State<CalendarEditorPage> createState() => _CalendarEditorPageState();
+}
+
+class _CalendarEditorPageState extends State<CalendarEditorPage> {
+  late List<String> allVideos;
+  final String _subtitles = '';
+  String currentVideo = '';
+  bool wasDateRecorded = false;
+  DateTime _currentDate = DateTime.now();
+  late Color mainColor;
+  final String _currentDateStr = DateFormatUtils.getToday(isDayFirst: false);
+
+  @override
+  void initState() {
+    mainColor = ThemeService().isDarkTheme() ? Colors.white : Colors.black;
+    allVideos = Utils.getAllVideos(fullPath: true);
+    getTodaysThumbnail();
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+  }
+
+  void getTodaysThumbnail() {
+    setState(() {
+      wasDateRecorded = allVideos.any((a) => a.contains(_currentDateStr));
+      if (wasDateRecorded) {
+        currentVideo = allVideos.firstWhere(
+          (a) => a.contains(_currentDateStr),
+        );
+      }
+    });
+  }
+
+  Future<Uint8List?> getThumbnail(String video) async {
+    final thumbnail = await VideoThumbnail.thumbnailData(
+      video: File(video).path,
+      imageFormat: ImageFormat.JPEG,
+      quality: 15,
+    );
+    return thumbnail;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Column(
+        children: [
+          const Text('Select a day to add or edit a video'),
+          Container(
+            margin: const EdgeInsets.symmetric(horizontal: 16.0),
+            child: CalendarCarousel<Event>(
+              onDayPressed: (DateTime date, List<Event> events) {
+                setState(
+                  () => _currentDate = date,
+                );
+                final currentVideoExists = allVideos.any(
+                  (a) => a.contains(
+                    DateFormatUtils.getDate(
+                      date,
+                      isDayFirst: false,
+                    ),
+                  ),
+                );
+                if (currentVideoExists) {
+                  setState(() {
+                    wasDateRecorded = true;
+                    currentVideo = allVideos.firstWhere(
+                      (a) => a.contains(
+                        DateFormatUtils.getDate(
+                          date,
+                          isDayFirst: false,
+                        ),
+                      ),
+                    );
+                  });
+                  print(currentVideo);
+                } else {
+                  setState(() {
+                    wasDateRecorded = false;
+                  });
+                }
+              },
+              customDayBuilder: (
+                bool isSelectable,
+                int index,
+                bool isSelectedDay,
+                bool isToday,
+                bool isPrevMonthDay,
+                TextStyle textStyle,
+                bool isNextMonthDay,
+                bool isThisMonthDay,
+                DateTime date,
+              ) {
+                final hasVideo = allVideos.any(
+                  (a) => a.contains(
+                    DateFormatUtils.getDate(
+                      date,
+                      isDayFirst: false,
+                    ),
+                  ),
+                );
+                if (DateTime.now().compareTo(date) != -1) {
+                  return Center(
+                    child: Text(
+                      date.day.toString(),
+                      style: TextStyle(
+                        color: hasVideo ? Colors.green : Colors.red,
+                        fontFamily: 'Magic',
+                      ),
+                    ),
+                  );
+                } else {
+                  return null;
+                }
+              },
+              selectedDayBorderColor: mainColor,
+              selectedDayButtonColor: Colors.transparent,
+              weekendTextStyle: TextStyle(
+                color: mainColor,
+                fontFamily: 'Magic',
+              ),
+              thisMonthDayBorderColor: Colors.transparent,
+              todayButtonColor: Colors.transparent,
+              todayBorderColor: Colors.grey,
+              todayTextStyle: TextStyle(
+                fontFamily: 'Magic',
+                color: mainColor,
+              ),
+              inactiveDaysTextStyle: const TextStyle(
+                fontFamily: 'Magic',
+              ),
+              nextDaysTextStyle: const TextStyle(
+                color: Colors.grey,
+                fontFamily: 'Magic',
+              ),
+              prevDaysTextStyle: const TextStyle(
+                color: Colors.grey,
+                fontFamily: 'Magic',
+              ),
+              weekdayTextStyle: const TextStyle(
+                fontFamily: 'Magic',
+              ),
+              weekFormat: false,
+              iconColor: ThemeService().isDarkTheme()
+                  ? Colors.white
+                  : Colors.black, // Color of icon
+              headerTextStyle: TextStyle(
+                fontSize: 20.0,
+                color: mainColor,
+              ),
+              height: 350.0,
+              selectedDateTime: _currentDate,
+              daysHaveCircularBorder: true,
+              daysTextStyle: TextStyle(
+                fontFamily: 'Magic',
+                color: mainColor,
+              ),
+            ),
+          ),
+          const SizedBox(
+            height: 20.0,
+          ),
+          if (wasDateRecorded)
+            Row(
+              children: [
+                Expanded(
+                  flex: 2,
+                  child: AspectRatio(
+                    aspectRatio: 16 / 8,
+                    child: Padding(
+                      padding: const EdgeInsets.only(left: 20.0),
+                      child: FutureBuilder(
+                        future: getThumbnail(currentVideo),
+                        builder: (context, snapshot) {
+                          if (snapshot.connectionState ==
+                              ConnectionState.waiting) {
+                            return const Center(
+                              child: SizedBox(
+                                height: 30,
+                                width: 30,
+                                child: CircularProgressIndicator(),
+                              ),
+                            );
+                          }
+
+                          if (snapshot.hasError) {
+                            return Text(
+                              '${snapshot.error}',
+                            );
+                          }
+                          return Image.memory(snapshot.data as Uint8List);
+                        },
+                      ),
+                    ),
+                  ),
+                ),
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.all(8.0),
+                    child: ElevatedButton(
+                      // Circle
+                      style: ElevatedButton.styleFrom(
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(30.0),
+                        ),
+                      ),
+                      onPressed: () {
+                        null;
+                      },
+                      child: Text('edit'.tr),
+                    ),
+                  ),
+                ),
+              ],
+            )
+          else
+            const Center(
+              child: Text('No video recorded for this day'),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+// TextField(
+//                         cursorColor: Colors.green,
+//                         maxLines: null,
+//                         onChanged: (value) => setState(() {
+//                           _subtitles = value;
+//                         }),
+//                         decoration: InputDecoration(
+//                           hintText: 'enterSubtitles'.tr,
+//                           filled: true,
+//                           border: const OutlineInputBorder(
+//                             borderSide: BorderSide(color: Colors.green),
+//                           ),
+//                           enabledBorder: InputBorder.none,
+//                           focusedBorder: const OutlineInputBorder(
+//                             borderSide: BorderSide(color: Colors.green),
+//                           ),
+//                         ),
+//                       ),

--- a/lib/pages/home/calendar_editor/calendar_editor_page.dart
+++ b/lib/pages/home/calendar_editor/calendar_editor_page.dart
@@ -71,7 +71,6 @@ class _CalendarEditorPageState extends State<CalendarEditorPage> {
     return SingleChildScrollView(
       child: Column(
         children: [
-          const Text('Select a day to add or edit a video'),
           Container(
             margin: const EdgeInsets.symmetric(horizontal: 16.0),
             child: CalendarCarousel<Event>(
@@ -258,15 +257,46 @@ class _CalendarEditorPageState extends State<CalendarEditorPage> {
                           ),
                         );
                       },
-                      child: Text('editSubtitles'.tr),
+                      child: Text(
+                        'editSubtitles'.tr,
+                        textAlign: TextAlign.center,
+                      ),
                     ),
                   ),
                 ),
               ],
             )
           else
-            const Center(
-              child: Text('No video recorded for this day'),
+            Column(
+              children: [
+                const SizedBox(
+                  height: 20.0,
+                ),
+                Text('noVideoRecorded'.tr),
+                const SizedBox(
+                  height: 10.0,
+                ),
+                Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: ElevatedButton(
+                    // Circle
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: AppColors.yellow,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(30.0),
+                      ),
+                    ),
+                    // TODO: implement
+                    onPressed: () {
+                      print('Add video from gallery');
+                    },
+                    child: Text(
+                      'addVideo'.tr,
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                ),
+              ],
             ),
         ],
       ),

--- a/lib/pages/home/calendar_editor/calendar_editor_page.dart
+++ b/lib/pages/home/calendar_editor/calendar_editor_page.dart
@@ -26,7 +26,7 @@ class CalendarEditorPage extends StatefulWidget {
 
 class _CalendarEditorPageState extends State<CalendarEditorPage> {
   late List<String> allVideos;
-  String subtitles = '';
+  late String? subtitles;
   String currentVideo = '';
   bool wasDateRecorded = false;
   DateTime _currentDate = DateTime.now();
@@ -247,7 +247,7 @@ class _CalendarEditorPageState extends State<CalendarEditorPage> {
                           });
                         } else {
                           setState(() {
-                            subtitles = '';
+                            subtitles = null;
                           });
                           print('No subtitles found');
                         }

--- a/lib/pages/home/calendar_editor/calendar_editor_page.dart
+++ b/lib/pages/home/calendar_editor/calendar_editor_page.dart
@@ -98,7 +98,6 @@ class _CalendarEditorPageState extends State<CalendarEditorPage> {
                       ),
                     );
                   });
-                  print(currentVideo);
                 } else {
                   setState(() {
                     wasDateRecorded = false;
@@ -223,7 +222,6 @@ class _CalendarEditorPageState extends State<CalendarEditorPage> {
                   child: Padding(
                     padding: const EdgeInsets.all(8.0),
                     child: ElevatedButton(
-                      // Circle
                       style: ElevatedButton.styleFrom(
                         backgroundColor: AppColors.mainColor,
                         shape: RoundedRectangleBorder(
@@ -242,13 +240,13 @@ class _CalendarEditorPageState extends State<CalendarEditorPage> {
                           final srtFile = await File(srtPath).readAsString();
                           setState(() {
                             subtitles = srtFile.trim().split(',000').last;
-                            print('srtFileContent -> $subtitles');
+                            debugPrint('srtFileContent -> $subtitles');
                           });
                         } else {
                           setState(() {
                             subtitles = null;
                           });
-                          print('No subtitles found');
+                          debugPrint('No subtitles found');
                         }
                         Get.to(
                           VideoSubtitlesEditorPage(
@@ -279,7 +277,6 @@ class _CalendarEditorPageState extends State<CalendarEditorPage> {
                 Padding(
                   padding: const EdgeInsets.all(8.0),
                   child: ElevatedButton(
-                    // Circle
                     style: ElevatedButton.styleFrom(
                       backgroundColor: AppColors.yellow,
                       shape: RoundedRectangleBorder(
@@ -287,9 +284,7 @@ class _CalendarEditorPageState extends State<CalendarEditorPage> {
                       ),
                     ),
                     // TODO: implement
-                    onPressed: () {
-                      print('Add video from gallery');
-                    },
+                    onPressed: () {},
                     child: Text(
                       'addVideo'.tr,
                       textAlign: TextAlign.center,

--- a/lib/pages/home/calendar_editor/calendar_editor_page.dart
+++ b/lib/pages/home/calendar_editor/calendar_editor_page.dart
@@ -74,6 +74,7 @@ class _CalendarEditorPageState extends State<CalendarEditorPage> {
           Container(
             margin: const EdgeInsets.symmetric(horizontal: 16.0),
             child: CalendarCarousel<Event>(
+              childAspectRatio: 1.05,
               onDayPressed: (DateTime date, List<Event> events) {
                 setState(
                   () => _currentDate = date,
@@ -115,6 +116,9 @@ class _CalendarEditorPageState extends State<CalendarEditorPage> {
                 bool isThisMonthDay,
                 DateTime date,
               ) {
+                final firstRecVideoDate = DateTime.parse(
+                  allVideos.first.split('/').last.split('.').first,
+                );
                 final hasVideo = allVideos.any(
                   (a) => a.contains(
                     DateFormatUtils.getDate(
@@ -123,7 +127,8 @@ class _CalendarEditorPageState extends State<CalendarEditorPage> {
                     ),
                   ),
                 );
-                if (DateTime.now().compareTo(date) != -1) {
+                if (DateTime.now().compareTo(date) != -1 &&
+                    firstRecVideoDate.compareTo(date) != 1) {
                   return Center(
                     child: Text(
                       date.day.toString(),
@@ -161,13 +166,14 @@ class _CalendarEditorPageState extends State<CalendarEditorPage> {
                 color: Colors.grey,
                 fontFamily: 'Magic',
               ),
-              weekdayTextStyle: const TextStyle(
+              weekdayTextStyle: TextStyle(
                 fontFamily: 'Magic',
+                color: mainColor,
+                fontWeight: FontWeight.w900,
               ),
               weekFormat: false,
-              iconColor: ThemeService().isDarkTheme()
-                  ? Colors.white
-                  : Colors.black, // Color of icon
+              iconColor:
+                  ThemeService().isDarkTheme() ? Colors.white : Colors.black, // Color of icon
               headerTextStyle: TextStyle(
                 fontSize: 20.0,
                 color: mainColor,
@@ -184,7 +190,7 @@ class _CalendarEditorPageState extends State<CalendarEditorPage> {
           const SizedBox(
             height: 20.0,
           ),
-          if (wasDateRecorded)
+          if (wasDateRecorded) ...{
             Row(
               children: [
                 Expanded(
@@ -196,13 +202,14 @@ class _CalendarEditorPageState extends State<CalendarEditorPage> {
                       child: FutureBuilder(
                         future: getThumbnail(currentVideo),
                         builder: (context, snapshot) {
-                          if (snapshot.connectionState ==
-                              ConnectionState.waiting) {
-                            return const Center(
+                          if (snapshot.connectionState == ConnectionState.waiting) {
+                            return Center(
                               child: SizedBox(
                                 height: 30,
                                 width: 30,
-                                child: CircularProgressIndicator(),
+                                child: CircularProgressIndicator(
+                                  color: mainColor,
+                                ),
                               ),
                             );
                           }
@@ -229,8 +236,7 @@ class _CalendarEditorPageState extends State<CalendarEditorPage> {
                         ),
                       ),
                       onPressed: () async {
-                        final Directory directory =
-                            await getApplicationDocumentsDirectory();
+                        final Directory directory = await getApplicationDocumentsDirectory();
                         final String srtPath = '${directory.path}/temp.srt';
                         final getSubsFile =
                             await executeFFmpeg('-i $currentVideo $srtPath -y');
@@ -264,7 +270,7 @@ class _CalendarEditorPageState extends State<CalendarEditorPage> {
                 ),
               ],
             )
-          else
+          } else ...{
             Column(
               children: [
                 const SizedBox(
@@ -293,6 +299,7 @@ class _CalendarEditorPageState extends State<CalendarEditorPage> {
                 ),
               ],
             ),
+          }
         ],
       ),
     );

--- a/lib/pages/home/calendar_editor/video_subtitles_editor_page.dart
+++ b/lib/pages/home/calendar_editor/video_subtitles_editor_page.dart
@@ -17,7 +17,7 @@ class VideoSubtitlesEditorPage extends StatefulWidget {
   });
 
   final String videoPath;
-  final String subtitles;
+  final String? subtitles;
 
   @override
   State<VideoSubtitlesEditorPage> createState() =>
@@ -35,9 +35,9 @@ class _VideoSubtitlesEditorPageState extends State<VideoSubtitlesEditorPage> {
   @override
   void initState() {
     _initVideoPlayerController();
-    if (widget.subtitles.isNotEmpty) {
-      subtitlesController.text = widget.subtitles;
-      _subtitles = widget.subtitles;
+    if (widget.subtitles != null) {
+      subtitlesController.text = widget.subtitles!;
+      _subtitles = widget.subtitles!;
       isEdit = true;
     }
 

--- a/lib/pages/home/calendar_editor/video_subtitles_editor_page.dart
+++ b/lib/pages/home/calendar_editor/video_subtitles_editor_page.dart
@@ -41,7 +41,6 @@ class _VideoSubtitlesEditorPageState extends State<VideoSubtitlesEditorPage> {
           .replaceAll('\n', ' ')
           .replaceAll(RegExp(r'\s+'), ' ');
       subtitlesController.text = _subtitles;
-      print(_subtitles);
       isEdit = true;
     }
 
@@ -146,7 +145,6 @@ class _VideoSubtitlesEditorPageState extends State<VideoSubtitlesEditorPage> {
                   setState(() {
                     isProcessing = true;
                   });
-                  print('running');
                   final subtitles = await Utils.writeSrt(
                     _subtitles,
                     _videoController.value.duration.inSeconds,
@@ -167,14 +165,13 @@ class _VideoSubtitlesEditorPageState extends State<VideoSubtitlesEditorPage> {
                   }
 
                   await executeFFmpeg(command).then((session) async {
-                    print(session.getCommand().toString());
                     final returnCode = await session.getReturnCode();
                     if (ReturnCode.isSuccess(returnCode)) {
-                      print('Video edited successfully');
+                      debugPrint('Video edited successfully');
                       StorageUtils.deleteFile(widget.videoPath);
                       StorageUtils.renameFile(tempPath, widget.videoPath);
                     } else {
-                      print('Video editing failed');
+                      debugPrint('Video editing failed');
                       final sessionLog = await session.getAllLogsAsString();
                       final failureStackTrace =
                           await session.getFailStackTrace();

--- a/lib/pages/home/calendar_editor/video_subtitles_editor_page.dart
+++ b/lib/pages/home/calendar_editor/video_subtitles_editor_page.dart
@@ -36,8 +36,12 @@ class _VideoSubtitlesEditorPageState extends State<VideoSubtitlesEditorPage> {
   void initState() {
     _initVideoPlayerController();
     if (widget.subtitles != null) {
-      subtitlesController.text = widget.subtitles!;
-      _subtitles = widget.subtitles!;
+      _subtitles = widget.subtitles!
+          .trim()
+          .replaceAll('\n', ' ')
+          .replaceAll(RegExp(r'\s+'), ' ');
+      subtitlesController.text = _subtitles;
+      print(_subtitles);
       isEdit = true;
     }
 
@@ -62,136 +66,145 @@ class _VideoSubtitlesEditorPageState extends State<VideoSubtitlesEditorPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('')),
+      appBar: AppBar(
+        title: Text('subtitles'.tr),
+      ),
+      resizeToAvoidBottomInset: false,
       body: Column(
-        mainAxisAlignment: MainAxisAlignment.spaceAround,
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
-          GestureDetector(
-            onTap: () => videoPlay(),
-            child: AspectRatio(
-              aspectRatio: 16 / 9,
-              child: Stack(
-                children: [
-                  VideoPlayer(_videoController),
-                  Center(
-                    child: Opacity(
-                      opacity: _opacity,
-                      child: Container(
-                        width: MediaQuery.of(context).size.width * 0.25,
-                        height: MediaQuery.of(context).size.width * 0.25,
-                        decoration: const BoxDecoration(
-                          color: Colors.black45,
-                          shape: BoxShape.circle,
-                        ),
-                        child: const Center(
-                          child: Icon(
-                            Icons.play_arrow,
-                            size: 72.0,
-                            color: Colors.white,
+          Column(
+            children: [
+              GestureDetector(
+                onTap: () => videoPlay(),
+                child: AspectRatio(
+                  aspectRatio: 16 / 9,
+                  child: Stack(
+                    children: [
+                      VideoPlayer(_videoController),
+                      Center(
+                        child: Opacity(
+                          opacity: _opacity,
+                          child: Container(
+                            width: MediaQuery.of(context).size.width * 0.25,
+                            height: MediaQuery.of(context).size.width * 0.25,
+                            decoration: const BoxDecoration(
+                              color: Colors.black45,
+                              shape: BoxShape.circle,
+                            ),
+                            child: const Center(
+                              child: Icon(
+                                Icons.play_arrow,
+                                size: 72.0,
+                                color: Colors.white,
+                              ),
+                            ),
                           ),
                         ),
                       ),
+                    ],
+                  ),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: TextField(
+                  controller: subtitlesController,
+                  cursorColor: Colors.green,
+                  maxLines: null,
+                  onChanged: (value) => setState(() {
+                    _subtitles = value;
+                  }),
+                  decoration: InputDecoration(
+                    hintText: 'enterSubtitles'.tr,
+                    filled: true,
+                    border: const OutlineInputBorder(
+                      borderSide: BorderSide(color: Colors.green),
+                    ),
+                    focusedBorder: const OutlineInputBorder(
+                      borderSide: BorderSide(color: Colors.green),
                     ),
                   ),
-                ],
+                ),
               ),
-            ),
+            ],
           ),
-          const Text('Subtitles'),
           Padding(
-            padding: const EdgeInsets.all(8.0),
-            child: TextField(
-              controller: subtitlesController,
-              cursorColor: Colors.green,
-              maxLines: null,
-              onChanged: (value) => setState(() {
-                _subtitles = value;
-              }),
-              decoration: InputDecoration(
-                hintText: 'enterSubtitles'.tr,
-                filled: true,
-                border: const OutlineInputBorder(
-                  borderSide: BorderSide(color: Colors.green),
+            padding: const EdgeInsets.all(15.0),
+            child: SizedBox(
+              width: MediaQuery.of(context).size.width * 0.45,
+              height: MediaQuery.of(context).size.height * 0.08,
+              child: ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  elevation: 5.0,
+                  backgroundColor: Colors.green,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(80.0),
+                  ),
                 ),
-                enabledBorder: InputBorder.none,
-                focusedBorder: const OutlineInputBorder(
-                  borderSide: BorderSide(color: Colors.green),
-                ),
-              ),
-            ),
-          ),
-          SizedBox(
-            width: MediaQuery.of(context).size.width * 0.45,
-            height: MediaQuery.of(context).size.height * 0.08,
-            child: ElevatedButton(
-              style: ElevatedButton.styleFrom(
-                elevation: 5.0,
-                backgroundColor: Colors.green,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(80.0),
-                ),
-              ),
-              onPressed: () async {
-                setState(() {
-                  isProcessing = true;
-                });
-                print('running');
-                final subtitles = await Utils.writeSrt(
-                  _subtitles,
-                  _videoController.value.duration.inSeconds,
-                );
+                onPressed: () async {
+                  setState(() {
+                    isProcessing = true;
+                  });
+                  print('running');
+                  final subtitles = await Utils.writeSrt(
+                    _subtitles,
+                    _videoController.value.duration.inSeconds,
+                  );
 
-                String command = '';
-                final String tempPath =
-                    '${widget.videoPath.split('.mp4').first}_temp.mp4';
+                  String command = '';
+                  final String tempPath =
+                      '${widget.videoPath.split('.mp4').first}_temp.mp4';
 
-                if (isEdit) {
-                  debugPrint('editing subtitles');
-                  command =
-                      '-i ${widget.videoPath} -i $subtitles -c:s mov_text -c:v copy -c:a copy -map 0:v -map 0:a? -map 1 -disposition:s:0 default $tempPath -y';
-                } else {
-                  debugPrint('adding new subtitles');
-                  command =
-                      '-i ${widget.videoPath} -i $subtitles -c copy -c:s mov_text $tempPath -y';
-                }
-
-                await executeFFmpeg(command).then((session) async {
-                  print(session.getCommand().toString());
-                  final returnCode = await session.getReturnCode();
-                  if (ReturnCode.isSuccess(returnCode)) {
-                    print('Video edited successfully');
-                    StorageUtils.deleteFile(widget.videoPath);
-                    StorageUtils.renameFile(tempPath, widget.videoPath);
+                  if (isEdit) {
+                    debugPrint('editing subtitles');
+                    command =
+                        '-i ${widget.videoPath} -i $subtitles -c:s mov_text -c:v copy -c:a copy -map 0:v -map 0:a? -map 1 -disposition:s:0 default $tempPath -y';
                   } else {
-                    print('Video editing failed');
-                    final sessionLog = await session.getAllLogsAsString();
-                    final failureStackTrace = await session.getFailStackTrace();
-                    debugPrint(
-                        'Session lasted for ${await session.getDuration()} ms');
-                    debugPrint(session.getArguments().toString());
-                    debugPrint('Session log is $sessionLog');
-                    debugPrint('Failure stacktrace - $failureStackTrace');
+                    debugPrint('adding new subtitles');
+                    command =
+                        '-i ${widget.videoPath} -i $subtitles -c copy -c:s mov_text $tempPath -y';
                   }
-                });
 
-                setState(() {
-                  isProcessing = false;
-                });
-                Get.back();
-              },
-              child: !isProcessing
-                  ? Text(
-                      'save'.tr,
-                      style: TextStyle(
-                        color: Colors.white,
-                        fontSize: MediaQuery.of(context).size.width * 0.07,
+                  await executeFFmpeg(command).then((session) async {
+                    print(session.getCommand().toString());
+                    final returnCode = await session.getReturnCode();
+                    if (ReturnCode.isSuccess(returnCode)) {
+                      print('Video edited successfully');
+                      StorageUtils.deleteFile(widget.videoPath);
+                      StorageUtils.renameFile(tempPath, widget.videoPath);
+                    } else {
+                      print('Video editing failed');
+                      final sessionLog = await session.getAllLogsAsString();
+                      final failureStackTrace =
+                          await session.getFailStackTrace();
+                      debugPrint(
+                          'Session lasted for ${await session.getDuration()} ms');
+                      debugPrint(session.getArguments().toString());
+                      debugPrint('Session log is $sessionLog');
+                      debugPrint('Failure stacktrace - $failureStackTrace');
+                    }
+                  });
+
+                  setState(() {
+                    isProcessing = false;
+                  });
+                  Get.back();
+                },
+                child: !isProcessing
+                    ? Text(
+                        'save'.tr,
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontSize: MediaQuery.of(context).size.width * 0.07,
+                        ),
+                      )
+                    : const CircularProgressIndicator(
+                        valueColor: AlwaysStoppedAnimation<Color>(
+                          Colors.white,
+                        ),
                       ),
-                    )
-                  : const CircularProgressIndicator(
-                      valueColor: AlwaysStoppedAnimation<Color>(
-                        Colors.white,
-                      ),
-                    ),
+              ),
             ),
           ),
         ],

--- a/lib/pages/home/calendar_editor/video_subtitles_editor_page.dart
+++ b/lib/pages/home/calendar_editor/video_subtitles_editor_page.dart
@@ -1,0 +1,215 @@
+import 'dart:io';
+
+import 'package:ffmpeg_kit_flutter_full_gpl/return_code.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:video_player/video_player.dart';
+
+import '../../../utils/ffmpeg_api_wrapper.dart';
+import '../../../utils/storage_utils.dart';
+import '../../../utils/utils.dart';
+
+class VideoSubtitlesEditorPage extends StatefulWidget {
+  const VideoSubtitlesEditorPage({
+    super.key,
+    required this.videoPath,
+    required this.subtitles,
+  });
+
+  final String videoPath;
+  final String subtitles;
+
+  @override
+  State<VideoSubtitlesEditorPage> createState() =>
+      _VideoSubtitlesEditorPageState();
+}
+
+class _VideoSubtitlesEditorPageState extends State<VideoSubtitlesEditorPage> {
+  double _opacity = 1.0;
+  String _subtitles = '';
+  bool isProcessing = false;
+  bool isEdit = false;
+  late VideoPlayerController _videoController;
+  final TextEditingController subtitlesController = TextEditingController();
+
+  @override
+  void initState() {
+    _initVideoPlayerController();
+    if (widget.subtitles.isNotEmpty) {
+      subtitlesController.text = widget.subtitles;
+      _subtitles = widget.subtitles;
+      isEdit = true;
+    }
+
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    _videoController.dispose();
+    super.dispose();
+  }
+
+  void _initVideoPlayerController() {
+    _videoController = VideoPlayerController.file(File(widget.videoPath))
+      ..initialize().then((_) {
+        _videoController.setLooping(true);
+        // Ensure the first frame is shown after the video is initialized, even before the play button has been pressed.
+        setState(() {});
+      });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('')),
+      body: Column(
+        mainAxisAlignment: MainAxisAlignment.spaceAround,
+        children: [
+          GestureDetector(
+            onTap: () => videoPlay(),
+            child: AspectRatio(
+              aspectRatio: 16 / 9,
+              child: Stack(
+                children: [
+                  VideoPlayer(_videoController),
+                  Center(
+                    child: Opacity(
+                      opacity: _opacity,
+                      child: Container(
+                        width: MediaQuery.of(context).size.width * 0.25,
+                        height: MediaQuery.of(context).size.width * 0.25,
+                        decoration: const BoxDecoration(
+                          color: Colors.black45,
+                          shape: BoxShape.circle,
+                        ),
+                        child: const Center(
+                          child: Icon(
+                            Icons.play_arrow,
+                            size: 72.0,
+                            color: Colors.white,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const Text('Subtitles'),
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: TextField(
+              controller: subtitlesController,
+              cursorColor: Colors.green,
+              maxLines: null,
+              onChanged: (value) => setState(() {
+                _subtitles = value;
+              }),
+              decoration: InputDecoration(
+                hintText: 'enterSubtitles'.tr,
+                filled: true,
+                border: const OutlineInputBorder(
+                  borderSide: BorderSide(color: Colors.green),
+                ),
+                enabledBorder: InputBorder.none,
+                focusedBorder: const OutlineInputBorder(
+                  borderSide: BorderSide(color: Colors.green),
+                ),
+              ),
+            ),
+          ),
+          SizedBox(
+            width: MediaQuery.of(context).size.width * 0.45,
+            height: MediaQuery.of(context).size.height * 0.08,
+            child: ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                elevation: 5.0,
+                backgroundColor: Colors.green,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(80.0),
+                ),
+              ),
+              onPressed: () async {
+                setState(() {
+                  isProcessing = true;
+                });
+                print('running');
+                final subtitles = await Utils.writeSrt(
+                  _subtitles,
+                  _videoController.value.duration.inSeconds,
+                );
+
+                String command = '';
+                final String tempPath =
+                    '${widget.videoPath.split('.mp4').first}_temp.mp4';
+
+                if (isEdit) {
+                  debugPrint('editing subtitles');
+                  command =
+                      '-i ${widget.videoPath} -i $subtitles -c:s mov_text -c:v copy -c:a copy -map 0:v -map 0:a? -map 1 -disposition:s:0 default $tempPath -y';
+                } else {
+                  debugPrint('adding new subtitles');
+                  command =
+                      '-i ${widget.videoPath} -i $subtitles -c copy -c:s mov_text $tempPath -y';
+                }
+
+                await executeFFmpeg(command).then((session) async {
+                  print(session.getCommand().toString());
+                  final returnCode = await session.getReturnCode();
+                  if (ReturnCode.isSuccess(returnCode)) {
+                    print('Video edited successfully');
+                    StorageUtils.deleteFile(widget.videoPath);
+                    StorageUtils.renameFile(tempPath, widget.videoPath);
+                  } else {
+                    print('Video editing failed');
+                    final sessionLog = await session.getAllLogsAsString();
+                    final failureStackTrace = await session.getFailStackTrace();
+                    debugPrint(
+                        'Session lasted for ${await session.getDuration()} ms');
+                    debugPrint(session.getArguments().toString());
+                    debugPrint('Session log is $sessionLog');
+                    debugPrint('Failure stacktrace - $failureStackTrace');
+                  }
+                });
+
+                setState(() {
+                  isProcessing = false;
+                });
+                Get.back();
+              },
+              child: !isProcessing
+                  ? Text(
+                      'save'.tr,
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: MediaQuery.of(context).size.width * 0.07,
+                      ),
+                    )
+                  : const CircularProgressIndicator(
+                      valueColor: AlwaysStoppedAnimation<Color>(
+                        Colors.white,
+                      ),
+                    ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void videoPlay() async {
+    if (!_videoController.value.isPlaying) {
+      await _videoController.play();
+      setState(() {
+        _opacity = 0.0;
+      });
+    } else {
+      await _videoController.pause();
+      setState(() {
+        _opacity = 1.0;
+      });
+    }
+  }
+}

--- a/lib/pages/home/create_movie/create_movie_screen.dart
+++ b/lib/pages/home/create_movie/create_movie_screen.dart
@@ -8,25 +8,26 @@ import 'widgets/video_count_card.dart';
 class CreateMoviePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.spaceAround,
-      children: [
-        const SizedBox(),
-        Text(
-          'totalRecordedTitle'.tr,
-          style: TextStyle(fontSize: MediaQuery.of(context).size.width * 0.07),
-          textAlign: TextAlign.center,
-        ),
-        VideoCountCard(),
-        SizedBox(height: MediaQuery.of(context).size.height * 0.1),
-        Text(
-          'tapBelowToGenerate'.tr,
-          style: TextStyle(fontSize: MediaQuery.of(context).size.width * 0.045),
-          textAlign: TextAlign.center,
-        ),
-        const _CreateMovieOptionsButton(),
-        const SizedBox(),
-      ],
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 40.0),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Column(
+            children: [
+              Text(
+                'totalRecordedTitle'.tr,
+                style: TextStyle(
+                    fontSize: MediaQuery.of(context).size.width * 0.07),
+                textAlign: TextAlign.center,
+              ),
+              SizedBox(height: MediaQuery.of(context).size.height * 0.05),
+              VideoCountCard(),
+            ],
+          ),
+          const _CreateMovieOptionsButton(),
+        ],
+      ),
     );
   }
 }
@@ -49,7 +50,7 @@ class _CreateMovieOptionsButton extends StatelessWidget {
         ),
         onPressed: () async => await Get.toNamed(Routes.CREATE_MOVIE_OPTIONS),
         child: Text(
-          'create'.tr,
+          'createMovie'.tr,
           style: TextStyle(
             color: Colors.white,
             fontSize: MediaQuery.of(context).size.width * 0.055,

--- a/lib/pages/home/create_movie/widgets/create_movie_button.dart
+++ b/lib/pages/home/create_movie/widgets/create_movie_button.dart
@@ -144,10 +144,10 @@ class _CreateMovieButtonState extends State<CreateMovieButton> {
               // Utils().logInfo('Video saved in gallery in the folder OSD-Movies!');
 
             } else if (ReturnCode.isCancel(returnCode)) {
-              print('Execution was cancelled');
+              debugPrint('Execution was cancelled');
             } else {
               // Utils().logError('$result');
-              print(
+              debugPrint(
                   'Error editing video: Return code is ${await session.getReturnCode()}');
               final sessionLog = await session.getAllLogsAsString();
               final failureStackTrace = await session.getFailStackTrace();

--- a/lib/pages/home/create_movie/widgets/create_movie_button.dart
+++ b/lib/pages/home/create_movie/widgets/create_movie_button.dart
@@ -91,6 +91,36 @@ class _CreateMovieButtonState extends State<CreateMovieButton> {
             '${SharedPrefsUtil.getString('moviesPath')}OneSecondDiary-Movie-${_movieCount.movieCount.value}-$today.mp4';
         // Utils().logInfo('It will be saved in: $outputPath');
 
+        // Make sure all selected videos have a subtitles stream before creating movie
+        for (String video in selectedVideos) {
+          await executeFFprobe(
+                  '-v quiet -select_streams s -show_streams $video')
+              .then((session) async {
+            final returnCode = await session.getReturnCode();
+            if (ReturnCode.isSuccess(returnCode)) {
+              final sessionLog = await session.getAllLogsAsString();
+              debugPrint('\n\nStream info for $video --> $sessionLog\n\n');
+              if (sessionLog == null || sessionLog.isEmpty) {
+                debugPrint('No subtitles stream for $video, adding one...');
+                final String tempPath = '${video.split('.mp4').first}_temp.mp4';
+                final String subtitles = await Utils.writeSrt('', 0);
+                final command =
+                    '-i $video -i $subtitles -c copy -c:s mov_text $tempPath -y';
+                await executeFFmpeg(command).then((session) async {
+                  final returnCode = await session.getReturnCode();
+                  if (ReturnCode.isSuccess(returnCode)) {
+                    StorageUtils.deleteFile(video);
+                    StorageUtils.renameFile(tempPath, video);
+                    debugPrint('Added empty subtitles stream to $video');
+                  } else {
+                    debugPrint('Error adding subtitles stream to $video');
+                  }
+                });
+              }
+            }
+          });
+        }
+
         await executeFFmpeg(
                 '-f concat -safe 0 -i $txtPath -map 0 -c copy $outputPath -y')
             .then(

--- a/lib/pages/home/create_movie/widgets/create_movie_options.dart
+++ b/lib/pages/home/create_movie/widgets/create_movie_options.dart
@@ -66,22 +66,14 @@ class _CreateMovieOptionsState extends State<CreateMovieOptions> {
                 children: [
                   Padding(
                     padding: EdgeInsets.only(
-                      left: MediaQuery.of(context).size.width * 0.04,
+                      left: MediaQuery.of(context).size.height * 0.025,
                       bottom: MediaQuery.of(context).size.height * 0.01,
                     ),
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        Text(
-                          'dateRange'.tr,
-                          style: TextStyle(
-                            fontSize:
-                                MediaQuery.of(context).size.height * 0.025,
-                          ),
-                        ),
-                        if (_exportPeriodGroupValue != ExportDateRange.custom)
-                          Text('${'clipsFound'.tr}: ${getClipsFound()}'),
-                      ],
+                    child: Text(
+                      'dateRange'.tr,
+                      style: TextStyle(
+                        fontSize: MediaQuery.of(context).size.height * 0.025,
+                      ),
                     ),
                   ),
                   Padding(
@@ -200,10 +192,23 @@ class _CreateMovieOptionsState extends State<CreateMovieOptions> {
               //     ),
               //   ],
               // ),
-
               const Spacer(),
-
-              // Create movie button
+              if (_exportPeriodGroupValue != ExportDateRange.custom)
+                Text(
+                  '${'clipsFound'.tr}: ${getClipsFound()}',
+                  style: TextStyle(
+                    fontSize: MediaQuery.of(context).size.width * 0.060,
+                  ),
+                ),
+              const Spacer(),
+              Text(
+                'tapBelowToGenerate'.tr,
+                style: TextStyle(
+                  fontSize: MediaQuery.of(context).size.width * 0.045,
+                ),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 20.0),
               CreateMovieButton(
                 selectedExportDateRange: _exportPeriodGroupValue,
                 // selectedOrientation: _orientationDefaultValue,

--- a/lib/pages/home/create_movie/widgets/select_video_from_storage.dart
+++ b/lib/pages/home/create_movie/widgets/select_video_from_storage.dart
@@ -127,7 +127,10 @@ class _SelectVideoFromStorageState extends State<SelectVideoFromStorage> {
                                   child: SizedBox(
                                     height: 30,
                                     width: 30,
-                                    child: CircularProgressIndicator(),
+                                    child: Padding(
+                                      padding: EdgeInsets.all(4.0),
+                                      child: CircularProgressIndicator(),
+                                    ),
                                   ),
                                 );
                               }

--- a/lib/pages/home/create_movie/widgets/select_video_from_storage.dart
+++ b/lib/pages/home/create_movie/widgets/select_video_from_storage.dart
@@ -23,6 +23,8 @@ class _SelectVideoFromStorageState extends State<SelectVideoFromStorage> {
   late List<GlobalKey> globalKeys;
   Map<String, Uint8List?> thumbnails = {};
   final ScrollController scrollController = ScrollController();
+  IconData selectIcon = Icons.select_all;
+  IconData navigationIcon = Icons.arrow_downward;
 
   @override
   void initState() {
@@ -41,19 +43,39 @@ class _SelectVideoFromStorageState extends State<SelectVideoFromStorage> {
         title: Text('selectVideos'.tr),
         actions: [
           IconButton(
-            icon: const Icon(Icons.deselect),
+            icon: Icon(navigationIcon),
             onPressed: () {
-              setState(() {
-                isSelected = List.filled(allVideos.length, false);
-              });
+              if (navigationIcon == Icons.arrow_downward) {
+                scrollController.jumpTo(
+                  scrollController.position.maxScrollExtent,
+                );
+                setState(() {
+                  navigationIcon = Icons.arrow_upward;
+                });
+              } else {
+                scrollController.jumpTo(
+                  scrollController.position.minScrollExtent,
+                );
+                setState(() {
+                  navigationIcon = Icons.arrow_downward;
+                });
+              }
             },
           ),
           IconButton(
-            icon: const Icon(Icons.select_all),
+            icon: Icon(selectIcon),
             onPressed: () {
-              setState(() {
-                isSelected = List.filled(allVideos.length, true);
-              });
+              if (selectIcon == Icons.select_all) {
+                setState(() {
+                  isSelected = List.filled(allVideos.length, true);
+                  selectIcon = Icons.deselect;
+                });
+              } else {
+                setState(() {
+                  isSelected = List.filled(allVideos.length, false);
+                  selectIcon = Icons.select_all;
+                });
+              }
             },
           ),
         ],
@@ -68,87 +90,80 @@ class _SelectVideoFromStorageState extends State<SelectVideoFromStorage> {
             ),
           ),
           Expanded(
-            child: Scrollbar(
-              thickness: 10,
-              thumbVisibility: true,
+            child: GridView.builder(
+              addAutomaticKeepAlives: true,
+              cacheExtent: 99999,
+              shrinkWrap: true,
               controller: scrollController,
-              interactive: true,
-              radius:
-                  const Radius.circular(10), // give the thumb rounded corners
-              child: GridView.builder(
-                addAutomaticKeepAlives: true,
-                cacheExtent: 100,
-                shrinkWrap: true,
-                controller: scrollController,
-                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                  crossAxisCount: 2,
-                  childAspectRatio: 1.12,
-                ),
-                itemCount: allVideos.length,
-                itemBuilder: (context, index) {
-                  return Column(
-                    children: [
-                      Text(
-                        allVideos[index].split('/').last.split('.mp4')[0],
-                        key: globalKeys[index],
-                      ),
-                      GestureDetector(
-                        onTap: () {
-                          setState(() {
-                            isSelected[index] = !isSelected[index];
-                          });
-                          if (isSelected[index] &&
-                              index != allVideos.length - 1) {
-                            scrollController.position.ensureVisible(
-                              globalKeys[index + 1]
-                                  .currentContext!
-                                  .findRenderObject()!,
-                              duration: const Duration(milliseconds: 750),
-                            );
-                          }
-                        },
-                        child: Container(
-                          margin: const EdgeInsets.all(15.0),
-                          decoration: BoxDecoration(
-                            border: Border.all(
-                              color: isSelected[index]
-                                  ? Colors.green
-                                  : Colors.white,
-                              width: isSelected[index] ? 4 : 1,
-                            ),
-                            borderRadius: BorderRadius.circular(5),
+              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: 2,
+                childAspectRatio: 1.12,
+              ),
+              itemCount: allVideos.length,
+              itemBuilder: (context, index) {
+                return Column(
+                  children: [
+                    Text(
+                      allVideos[index].split('/').last.split('.mp4')[0],
+                      key: globalKeys[index],
+                    ),
+                    GestureDetector(
+                      onTap: () {
+                        setState(() {
+                          isSelected[index] = !isSelected[index];
+                        });
+                        if (isSelected[index] &&
+                            index != allVideos.length - 1) {
+                          scrollController.position.ensureVisible(
+                            globalKeys[index + 1]
+                                .currentContext!
+                                .findRenderObject()!,
+                            duration: const Duration(milliseconds: 750),
+                          );
+                        }
+                      },
+                      child: Container(
+                        margin: const EdgeInsets.all(15.0),
+                        decoration: BoxDecoration(
+                          border: Border.all(
+                            color:
+                                isSelected[index] ? Colors.green : Colors.white,
+                            width: isSelected[index] ? 4 : 1,
                           ),
-                          child: LazyFutureBuilder(
-                            future: () => getThumbnail(allVideos[index]),
-                            builder: (context, snapshot) {
-                              if (snapshot.connectionState ==
-                                  ConnectionState.waiting) {
-                                return const Center(
-                                  child: SizedBox(
-                                    height: 30,
-                                    width: 30,
-                                    child: Padding(
-                                      padding: EdgeInsets.all(4.0),
-                                      child: CircularProgressIndicator(),
-                                    ),
+                          borderRadius: BorderRadius.circular(5),
+                        ),
+                        child: LazyFutureBuilder(
+                          future: () => getThumbnail(allVideos[index]),
+                          builder: (context, snapshot) {
+                            if (snapshot.connectionState ==
+                                ConnectionState.waiting) {
+                              return const Center(
+                                child: SizedBox(
+                                  height: 30,
+                                  width: 30,
+                                  child: Padding(
+                                    padding: EdgeInsets.all(4.0),
+                                    child: CircularProgressIndicator(),
                                   ),
-                                );
-                              }
+                                ),
+                              );
+                            }
 
-                              if (snapshot.hasError) {
-                                return Text(
-                                  '${snapshot.error}',
-                                );
-                              }
-                              return Image.memory(snapshot.data as Uint8List);
-                            },
-                          ),
+                            if (snapshot.hasError) {
+                              return Text(
+                                '${snapshot.error}',
+                              );
+                            }
+                            return Image.memory(
+                              snapshot.data as Uint8List,
+                            );
+                          },
                         ),
                       ),
-                    ],
-                  );
-                },
-              ),
+                    ),
+                  ],
+                );
+              },
             ),
           ),
           if (totalSelected >= 2) ...{

--- a/lib/pages/home/settings/widgets/about_button.dart
+++ b/lib/pages/home/settings/widgets/about_button.dart
@@ -2,32 +2,29 @@ import 'package:about/about.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
-import '../../../../controllers/lang_controller.dart';
+import '../../../../utils/constants.dart';
 
 class AboutButton extends StatelessWidget {
-  final LanguageController _languageController = Get.find();
-
   void showAbout(BuildContext context) {
     showAboutPage(
       title: Text('about'.tr),
       context: context,
       applicationVersion: 'appVersion'.tr,
-      applicationLegalese: 'Copyright © Caio Pedroso, 2021',
+      applicationLegalese: 'Copyright © Caio Pedroso, 2023',
       children: <Widget>[
-        MarkdownPageListTile(
-          filename: _languageController.selectedLanguage.value == 'pt'
-              ? 'TODO_pt.md'
-              : 'TODO.md',
-          title: Text('futureUpdates'.tr),
-          icon: const Icon(Icons.more_time_outlined),
-        ),
         const MarkdownPageListTile(
-          icon: Icon(Icons.list),
+          icon: Icon(
+            Icons.history,
+            color: AppColors.green,
+          ),
           title: Text('Changelog'),
           filename: 'CHANGELOG.md',
         ),
         MarkdownPageListTile(
-          icon: const Icon(Icons.favorite),
+          icon: const Icon(
+            Icons.favorite,
+            color: AppColors.mainColor,
+          ),
           title: Text('thanksTo'.tr),
           filename: 'CONTRIBUTORS.md',
         ),
@@ -47,23 +44,26 @@ class AboutButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(
       children: [
-        Container(
-          height: MediaQuery.of(context).size.height * 0.065,
-          padding: const EdgeInsets.symmetric(horizontal: 15.0),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Text(
-                'about'.tr,
-                style: TextStyle(
-                  fontSize: MediaQuery.of(context).size.width * 0.045,
+        GestureDetector(
+          onTap: () => showAbout(context),
+          child: Container(
+            height: MediaQuery.of(context).size.height * 0.065,
+            padding: const EdgeInsets.symmetric(horizontal: 15.0),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  'about'.tr,
+                  style: TextStyle(
+                    fontSize: MediaQuery.of(context).size.width * 0.045,
+                  ),
                 ),
-              ),
-              IconButton(
-                icon: const Icon(Icons.info),
-                onPressed: () => showAbout(context),
-              ),
-            ],
+                IconButton(
+                  icon: const Icon(Icons.info),
+                  onPressed: () => showAbout(context),
+                ),
+              ],
+            ),
           ),
         ),
         const Divider(),

--- a/lib/pages/home/settings/widgets/backup_tutorial.dart
+++ b/lib/pages/home/settings/widgets/backup_tutorial.dart
@@ -8,23 +8,26 @@ class BackupTutorial extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(
       children: [
-        Container(
-          height: MediaQuery.of(context).size.height * 0.065,
-          padding: const EdgeInsets.symmetric(horizontal: 15.0),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Text(
-                'Backup Tutorial',
-                style: TextStyle(
-                  fontSize: MediaQuery.of(context).size.width * 0.045,
+        GestureDetector(
+          onTap: () => Utils.launchURL(Constants.backupTutorialUrl),
+          child: Container(
+            height: MediaQuery.of(context).size.height * 0.065,
+            padding: const EdgeInsets.symmetric(horizontal: 15.0),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  'Backup Tutorial',
+                  style: TextStyle(
+                    fontSize: MediaQuery.of(context).size.width * 0.045,
+                  ),
                 ),
-              ),
-              IconButton(
-                icon: const Icon(Icons.backup),
-                onPressed: () => Utils.launchURL(Constants.backupTutorialUrl),
-              ),
-            ],
+                IconButton(
+                  icon: const Icon(Icons.backup),
+                  onPressed: () => Utils.launchURL(Constants.backupTutorialUrl),
+                ),
+              ],
+            ),
           ),
         ),
         const Divider(),

--- a/lib/pages/home/settings/widgets/contact_button.dart
+++ b/lib/pages/home/settings/widgets/contact_button.dart
@@ -9,23 +9,26 @@ class ContactButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(
       children: [
-        Container(
-          height: MediaQuery.of(context).size.height * 0.065,
-          padding: const EdgeInsets.symmetric(horizontal: 15.0),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Text(
-                'contact'.tr,
-                style: TextStyle(
-                  fontSize: MediaQuery.of(context).size.width * 0.045,
+        GestureDetector(
+          onTap: () => Utils.launchURL(Constants.email),
+          child: Container(
+            height: MediaQuery.of(context).size.height * 0.065,
+            padding: const EdgeInsets.symmetric(horizontal: 15.0),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  'contact'.tr,
+                  style: TextStyle(
+                    fontSize: MediaQuery.of(context).size.width * 0.045,
+                  ),
                 ),
-              ),
-              IconButton(
-                icon: const Icon(Icons.email),
-                onPressed: () => Utils.launchURL(Constants.email),
-              ),
-            ],
+                IconButton(
+                  icon: const Icon(Icons.email),
+                  onPressed: () => Utils.launchURL(Constants.email),
+                ),
+              ],
+            ),
           ),
         ),
         const Divider(),

--- a/lib/pages/home/settings/widgets/github_button.dart
+++ b/lib/pages/home/settings/widgets/github_button.dart
@@ -8,23 +8,26 @@ class GithubButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(
       children: [
-        Container(
-          height: MediaQuery.of(context).size.height * 0.065,
-          padding: const EdgeInsets.symmetric(horizontal: 15.0),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Text(
-                'GitHub',
-                style: TextStyle(
-                  fontSize: MediaQuery.of(context).size.width * 0.045,
+        GestureDetector(
+          onTap: () => Utils.launchURL(Constants.githubUrl),
+          child: Container(
+            height: MediaQuery.of(context).size.height * 0.065,
+            padding: const EdgeInsets.symmetric(horizontal: 15.0),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  'GitHub',
+                  style: TextStyle(
+                    fontSize: MediaQuery.of(context).size.width * 0.045,
+                  ),
                 ),
-              ),
-              IconButton(
-                icon: const Icon(Icons.code),
-                onPressed: () => Utils.launchURL(Constants.githubUrl),
-              ),
-            ],
+                IconButton(
+                  icon: const Icon(Icons.code),
+                  onPressed: () => Utils.launchURL(Constants.githubUrl),
+                ),
+              ],
+            ),
           ),
         ),
         const Divider(),

--- a/lib/pages/home/settings/widgets/notifications_button.dart
+++ b/lib/pages/home/settings/widgets/notifications_button.dart
@@ -11,7 +11,7 @@ class NotificationsButton extends StatelessWidget {
         GestureDetector(
           onTap: () => Get.toNamed(Routes.NOTIFICATION),
           child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 15.0, vertical: 10.0),
+            padding: const EdgeInsets.symmetric(horizontal: 15.0),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
@@ -20,6 +20,10 @@ class NotificationsButton extends StatelessWidget {
                   style: TextStyle(
                     fontSize: MediaQuery.of(context).size.width * 0.045,
                   ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.notifications),
+                  onPressed: () => Get.toNamed(Routes.NOTIFICATION),
                 ),
               ],
             ),

--- a/lib/pages/recording/recording_page.dart
+++ b/lib/pages/recording/recording_page.dart
@@ -301,7 +301,7 @@ class _RecordingPageState extends State<RecordingPage>
         ),
       );
     } on CameraException catch (e) {
-      print('$e');
+      debugPrint('$e');
       // Utils().logError(e);
       return null;
     }

--- a/lib/pages/save_video/save_video_page.dart
+++ b/lib/pages/save_video/save_video_page.dart
@@ -159,7 +159,7 @@ class _SaveVideoPageState extends State<SaveVideoPage> {
     _initVideoPlayerController();
     checkGeotaggingStatus().whenComplete(
       () {
-        print(_currentAddress);
+        debugPrint(_currentAddress);
         setState(() {});
       },
     );
@@ -458,7 +458,7 @@ class _SaveVideoPageState extends State<SaveVideoPage> {
           onChanged: (_) async {
             await toggleGeotaggingStatus();
             if (isGeotaggingEnabled) {
-              print('Getting location');
+              debugPrint('Getting location');
               await _getCurrentPosition();
             }
             setState(() {});

--- a/lib/pages/save_video/widgets/save_button.dart
+++ b/lib/pages/save_video/widgets/save_button.dart
@@ -57,7 +57,7 @@ class _SaveButtonState extends State<SaveButton> {
   final VideoCountController _videoCountController = Get.find();
 
   void _saveVideo() async {
-    print('Starting to save video');
+    debugPrint('Starting to save video');
     setState(() {
       isProcessing = true;
     });
@@ -69,7 +69,7 @@ class _SaveButtonState extends State<SaveButton> {
         isProcessing = false;
       });
     } catch (e) {
-      print(e);
+      debugPrint(e.toString());
 
       setState(() {
         isProcessing = false;
@@ -189,10 +189,10 @@ class _SaveButtonState extends State<SaveButton> {
     await executeFFmpeg(
       '-i $videoPath $subtitles -vf [in]drawtext="$fontPath:text=\'${widget.dateFormat}\':fontsize=$dateTextSize:fontcolor=\'$parsedDateColor\':borderw=${widget.textOutlineWidth}:bordercolor=$parsedTextOutlineColor:x=$datePosX:y=$datePosY$locOutput[out]" -codec:v libx264 -pix_fmt yuv420p $finalPath -y',
     ).then((session) async {
-      print(session.getCommand().toString());
+      debugPrint(session.getCommand().toString());
       final returnCode = await session.getReturnCode();
       if (ReturnCode.isSuccess(returnCode)) {
-        print('Video edited successfully');
+        debugPrint('Video edited successfully');
 
         _dayController.updateDaily();
 
@@ -215,9 +215,9 @@ class _SaveButtonState extends State<SaveButton> {
           ),
         );
       } else if (ReturnCode.isCancel(returnCode)) {
-        print('Execution was cancelled');
+        debugPrint('Execution was cancelled');
       } else {
-        print(
+        debugPrint(
             'Error editing video: Return code is ${await session.getReturnCode()}');
         final sessionLog = await session.getAllLogsAsString();
         final failureStackTrace = await session.getFailStackTrace();

--- a/lib/utils/storage_utils.dart
+++ b/lib/utils/storage_utils.dart
@@ -1,6 +1,5 @@
 import 'dart:io' as io;
 
-import 'package:get/get.dart';
 import 'package:path_provider/path_provider.dart';
 
 import 'shared_preferences_util.dart';
@@ -75,6 +74,17 @@ class StorageUtils {
     } catch (e) {
       print(e);
       // Utils().logError('$e');
+    }
+  }
+
+  /// Rename file
+  static bool renameFile(String oldPath, String newPath) {
+    try {
+      io.File(oldPath).renameSync(newPath);
+      return true;
+    } catch (e) {
+      print(e);
+      return false;
     }
   }
 

--- a/lib/utils/storage_utils.dart
+++ b/lib/utils/storage_utils.dart
@@ -1,5 +1,6 @@
 import 'dart:io' as io;
 
+import 'package:flutter/material.dart';
 import 'package:path_provider/path_provider.dart';
 
 import 'shared_preferences_util.dart';
@@ -10,14 +11,14 @@ class StorageUtils {
   static Future<void> createFolder() async {
     try {
       final hasStoragePerms = await Utils.requestStoragePermissions();
-      print('Storage perms enabled? $hasStoragePerms');
+      debugPrint('Storage permissions enabled? $hasStoragePerms');
 
       if (hasStoragePerms == false) {
         // Get.snackbar(
         //   'Oh no!',
         //   'Not all permissions were granted. Some app features may not work properly',
         // );
-        print('Looks like some permissions were not granted');
+        debugPrint('Looks like some permissions were not granted');
       }
 
       io.Directory? appDirectory;
@@ -72,7 +73,7 @@ class StorageUtils {
         // Utils().logInfo("Directory already exists");
       }
     } catch (e) {
-      print(e);
+      debugPrint(e.toString());
       // Utils().logError('$e');
     }
   }
@@ -83,7 +84,7 @@ class StorageUtils {
       io.File(oldPath).renameSync(newPath);
       return true;
     } catch (e) {
-      print(e);
+      debugPrint(e.toString());
       return false;
     }
   }

--- a/lib/utils/theme.dart
+++ b/lib/utils/theme.dart
@@ -6,11 +6,7 @@ import 'shared_preferences_util.dart';
 
 class Themes {
   static final light = ThemeData.light().copyWith(
-    appBarTheme: const AppBarTheme(
-      backgroundColor: AppColors.light,
-      titleTextStyle: TextStyle(color: Colors.black),
-      iconTheme: IconThemeData(color: Colors.black),
-    ),
+    appBarTheme: const AppBarTheme(backgroundColor: AppColors.mainColor),
     textTheme: ThemeData.light().textTheme.apply(fontFamily: 'Magic'),
     primaryColor: AppColors.mainColor,
     colorScheme: ColorScheme.fromSwatch().copyWith(

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -34,11 +34,10 @@ class Utils {
   // }
 
   static void launchURL(String url) async {
-    if (await canLaunch(url)) {
-      await launch(url);
-    } else {
-      throw 'Could not launch $url';
-    }
+    await launchUrl(
+      Uri.parse(url),
+      mode: LaunchMode.externalApplication,
+    );
   }
 
   /// Used to request Android permissions

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -324,19 +324,19 @@ class Utils {
     try {
       if (StorageUtils.checkFileExists(fontPath)) {
         // Utils().logInfo('Font already exists');
-        print('Font already exists');
+        debugPrint('Font already exists');
       } else {
         final ByteData data =
             await rootBundle.load('assets/fonts/YuseiMagic-Regular.ttf');
         final List<int> bytes =
             data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes);
         await io.File(fontPath).writeAsBytes(bytes);
-        print('Font copied to $fontPath');
+        debugPrint('Font copied to $fontPath');
         // Utils().logInfo('Font copied to $fontPath');
       }
     } catch (e) {
       // Utils().logError('$e');
-      print(e);
+      debugPrint(e.toString());
     }
 
     return fontPath;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -16,7 +16,7 @@ packages:
     source: hosted
     version: "2.3.1"
   async:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: async
       url: "https://pub.dartlang.org"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -16,7 +16,7 @@ packages:
     source: hosted
     version: "2.3.1"
   async:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -176,6 +176,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_calendar_carousel:
+    dependency: "direct main"
+    description:
+      name: flutter_calendar_carousel
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.4.1"
   flutter_colorpicker:
     dependency: "direct main"
     description:
@@ -339,7 +346,7 @@ packages:
       name: intl
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.18.0"
+    version: "0.17.0"
   introduction_screen:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   file_picker: ^5.2.4
   flutter:
     sdk: flutter
+  flutter_calendar_carousel: ^2.4.1
   flutter_colorpicker: ^1.0.3
   flutter_local_notifications: ^12.0.4
   fluttertoast: ^8.1.1
@@ -27,7 +28,7 @@ dependencies:
   geolocator: ^9.0.2
   get: ^4.6.5
   group_radio_button: ^1.3.0
-  intl: ^0.18.0
+  intl: ^0.17.0
   introduction_screen: ^3.1.1
   native_device_orientation: ^1.1.4
   open_file:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,13 +3,14 @@ description: Record one second of your day, everyday.
 
 publish_to: "none"
 
-version: 1.1.3+7
+version: 1.5.0+1
 
 environment:
   sdk: ">=2.18.2 <3.0.0"
 
 dependencies:
   about: ^2.1.1
+  async: ^2.9.0
   avatar_glow: ^2.0.2
   camera:
     git:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,6 @@ environment:
 
 dependencies:
   about: ^2.1.1
-  async: ^2.9.0
   avatar_glow: ^2.0.2
   camera:
     git:


### PR DESCRIPTION
1. Added a new Calendar view in home page (UI is not final, needs some serious polish). It leads to a subtitle editor page if a video was recorded for the selected day, otherwise it shows a button to a video from gallery (to be implemented).

2. Subtitle stream is now added by default (empty text) to all recordings since concat demuxer does not work properly if it is missing in a video. This is also checked when a movie is created, to avoid letting older recordings without a subtitle stream.

3. UI Tweaks in settings, create movie page and select videos page. Main change is removing scrollbar from select videos since fast scrolling with 500+ items was crashing the app because lots of Futures would start to obtain the thumbnails and not stop even after page popped. Added an action button to jump scroll to bottom or top instead.

4. Fixed URL launcher and subtitles feature for some edge cases.

5. Update translations and .MD files.

FYI @daoxve, please let me know if this conflits with what you're doing and I'll adapt what's needed. Thanks!