### PR TITLE
Add backward compatibility to movies creation and other fixes

### DIFF
--- a/lib/lang/de.dart
+++ b/lib/lang/de.dart
@@ -113,4 +113,9 @@ const Map<String, String> de = {
       'Alle mit diesem Profil verknüpften Videos werden ebenfalls dauerhaft gelöscht.Bist du sicher weiter? ',
   'profileNameCannotBeEmpty': 'Profilname kann nicht leer sein',
   'reservedProfileName': 'Dies ist ein reservierter Profilname',
+  'creatingMovie':
+      'Verarbeitung... Bitte warten.\nDies kann mehrere Minuten dauern.',
+  'doNotCloseTheApp': 'Bitte schließen Sie die\nApp nicht.',
+  'cancelMovieCreation': 'Film erstellen abbrechen',
+  'cancelMovieDesc': 'Möchtest Du wirklich abbrechen?',
 };

--- a/lib/lang/en.dart
+++ b/lib/lang/en.dart
@@ -17,14 +17,17 @@ const Map<String, String> en = {
   'movieCreatedTitle': 'Movie created!',
   'movieCreatedDesc': 'Movie saved to storage inside OSD-Movies folder',
   'movieError': 'Error saving the movie!',
-  'tryAgainMsg': 'Please try again. If the problem persists, contact the developer.',
+  'tryAgainMsg':
+      'Please try again. If the problem persists, contact the developer.',
   'create': 'Create',
   'days': 'days',
   'day': 'day',
   'totalRecordedTitle': 'You have recorded:',
-  'tapBelowToGenerate': 'Tap the button below to generate\na single video file:',
+  'tapBelowToGenerate':
+      'Tap the button below to generate\na single video file:',
   'editQuestionTitle': 'Edit video?',
-  'editQuestion': 'Your previous recording will be deleted, do you want to continue?',
+  'editQuestion':
+      'Your previous recording will be deleted, do you want to continue?',
   'yes': 'Yes',
   'no': 'No',
   'edit': 'Edit',
@@ -47,7 +50,8 @@ const Map<String, String> en = {
   'introTitle2': 'Create the movie of your life',
   'introDesc2': 'Generate a compilation of all your recorded videos.',
   'introTitle3': 'No ads and totally free',
-  'introDesc3': 'If you like the app, consider supporting the development with a donation.',
+  'introDesc3':
+      'If you like the app, consider supporting the development with a donation.',
   'skip': 'Skip',
   'done': 'Done',
   'futureUpdates': 'Future Updates',
@@ -110,4 +114,8 @@ const Map<String, String> en = {
       'All videos associated with this profile will also be permanently deleted. Are you sure to continue?',
   'profileNameCannotBeEmpty': 'Profile name cannot be empty',
   'reservedProfileName': 'This is a reserved profile name',
+  'creatingMovie': 'Processing... Please wait.\nThis can take several minutes.',
+  'doNotCloseTheApp': 'Do not close the app.',
+  'cancelMovieCreation': 'Cancel movie creation',
+  'cancelMovieDesc': 'Are you sure you want to cancel the movie creation?',
 };

--- a/lib/lang/es.dart
+++ b/lib/lang/es.dart
@@ -113,4 +113,10 @@ const Map<String, String> es = {
       'Todos los videos asociados con este perfil también se eliminarán permanentemente.¿Estás seguro de continuar?',
   'profileNameCannotBeEmpty': 'El nombre del perfil no puede estar vacío',
   'reservedProfileName': 'Este es un nombre de perfil reservado',
+  'creatingMovie':
+      'Procesando... Por favor espera.\nEsto puede tomar varios minutos.',
+  'doNotCloseTheApp': 'No cierres la aplicación.',
+  'cancelMovieCreation': 'Cancelar creación de película',
+  'cancelMovieDesc':
+      '¿Estás seguro de que quieres cancelar la creación de la película?',
 };

--- a/lib/lang/fr.dart
+++ b/lib/lang/fr.dart
@@ -115,4 +115,9 @@ const Map<String, String> fr = {
       'Toutes les vidéos associées à ce profil seront également supprimées en permanence. Êtes-vous sûr de continuer?',
   'profileNameCannotBeEmpty': 'Le nom du profil ne peut pas être vide',
   'reservedProfileName': 'Ceci est un nom de profil réservé',
+  'creatingMovie':
+      'Traitement... Veuillez patienter.\nCela peut prendre plusieurs minutes.',
+  'doNotCloseTheApp': 'Ne fermez pas l\'application.',
+  'cancelMovieCreation': 'Annuler la création du film',
+  'cancelMovieDesc': 'Voulez-vous vraiment annuler la création du film ?',
 };

--- a/lib/lang/id.dart
+++ b/lib/lang/id.dart
@@ -114,4 +114,9 @@ const Map<String, String> id = {
       'Semua video yang terkait dengan profil ini juga akan dihapus secara permanen.Apakah kamu pasti akan melanjutkan? ',
   'profileNameCannotBeEmpty': 'Nama profil tidak bisa kosong',
   'reservedProfileName': 'Ini adalah nama profil yang dipesan',
+  'creatingMovie':
+      'Memproses ... tunggu sebentar.\nIni bisa memakan waktu beberapa menit.',
+  'doNotCloseTheApp': 'Jangan tutup aplikasi ini.',
+  'cancelMovieCreation': 'Batalkan pembuatan video',
+  'cancelMovieDesc': 'Apakah Anda yakin ingin membatalkan pembuatan video?',
 };

--- a/lib/lang/pt.dart
+++ b/lib/lang/pt.dart
@@ -113,4 +113,9 @@ const Map<String, String> pt = {
       'Todos os vídeos associados a este perfil também serão excluídos permanentemente. Você tem certeza de continuar?',
   'profileNameCannotBeEmpty': 'O nome do perfil não pode estar vazio',
   'reservedProfileName': 'Este é um nome de perfil reservado',
+  'creatingMovie':
+      'Processando... Por favor, aguarde.\nIsso pode levar alguns minutos.',
+  'doNotCloseTheApp': 'Não feche o aplicativo.',
+  'cancelMovieCreation': 'Cancelar criação de filme',
+  'cancelMovieDesc': 'Você tem certeza que deseja cancelar a criação do filme?',
 };

--- a/lib/lang/zh.dart
+++ b/lib/lang/zh.dart
@@ -105,4 +105,8 @@ const Map<String, String> zh = {
   'deleteProfileTooltip': '与此配置文件相关的所有视频也将被永久删除。你一定会继续吗？',
   'profileNameCannotBeEmpty': '配置文件名称不能为空',
   'reservedProfileName': '这是一个保留的个人资料名称',
+  'creatingMovie': '正在处理...请稍候.\n这可能需要几分钟.',
+  'doNotCloseTheApp': '请不要关闭应用程序',
+  'cancelMovieCreation': '取消电影创建',
+  'cancelMovieDesc': '您确定要取消电影创建吗?',
 };

--- a/lib/pages/home/base/home_page.dart
+++ b/lib/pages/home/base/home_page.dart
@@ -15,6 +15,7 @@ class HomePage extends GetView<BottomAppBarIndexController> {
     return Scaffold(
       appBar: CustomAppBar(),
       bottomNavigationBar: CustomBottomAppBar(),
+      resizeToAvoidBottomInset: false,
       body: SizedBox(
         width: MediaQuery.of(context).size.width,
         height: MediaQuery.of(context).size.height,

--- a/lib/pages/home/create_movie/widgets/create_movie_options.dart
+++ b/lib/pages/home/create_movie/widgets/create_movie_options.dart
@@ -5,6 +5,7 @@ import '../../../../enums/export_date_range.dart';
 // import '../../../../enums/export_orientations.dart';
 import '../../../../routes/app_pages.dart';
 import '../../../../utils/constants.dart';
+import '../../../../utils/custom_dialog.dart';
 import '../../../../utils/theme.dart';
 import '../../../../utils/utils.dart';
 import 'create_movie_button.dart';
@@ -43,177 +44,197 @@ class _CreateMovieOptionsState extends State<CreateMovieOptions> {
       return selectedVideos.length.toString();
     }
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(
-          'createMovie'.tr,
-          style: TextStyle(
-            fontFamily: 'Magic',
-            fontSize: MediaQuery.of(context).size.width * 0.05,
+    return WillPopScope(
+      onWillPop: () async {
+        showDialog(
+          barrierDismissible: false,
+          context: Get.context!,
+          builder: (context) => CustomDialog(
+            isDoubleAction: true,
+            title: 'cancelMovie'.tr,
+            content: 'cancelMovieDesc'.tr,
+            actionText: 'yes'.tr,
+            actionColor: Colors.green,
+            action: () => Get.offAllNamed(Routes.HOME),
+            action2Text: 'no'.tr,
+            action2Color: Colors.red,
+            action2: () => Get.back(),
+          ),
+        );
+        return true;
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(
+            'createMovie'.tr,
+            style: TextStyle(
+              fontFamily: 'Magic',
+              fontSize: MediaQuery.of(context).size.width * 0.05,
+            ),
           ),
         ),
-      ),
-      body: Center(
-        child: SizedBox(
-          width: MediaQuery.of(context).size.width * 0.9,
-          height: MediaQuery.of(context).size.height * 0.8,
-          child: Column(
-            children: [
-              // Date range
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                children: [
-                  Padding(
-                    padding: EdgeInsets.only(
-                      left: MediaQuery.of(context).size.height * 0.025,
-                      bottom: MediaQuery.of(context).size.height * 0.01,
-                    ),
-                    child: Text(
-                      'dateRange'.tr,
-                      style: TextStyle(
-                        fontSize: MediaQuery.of(context).size.height * 0.025,
+        body: Center(
+          child: SizedBox(
+            width: MediaQuery.of(context).size.width * 0.9,
+            height: MediaQuery.of(context).size.height * 0.8,
+            child: Column(
+              children: [
+                // Date range
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  children: [
+                    Padding(
+                      padding: EdgeInsets.only(
+                        left: MediaQuery.of(context).size.height * 0.025,
+                        bottom: MediaQuery.of(context).size.height * 0.01,
                       ),
-                    ),
-                  ),
-                  Padding(
-                    padding: EdgeInsets.only(
-                      left: MediaQuery.of(context).size.height * 0.025,
-                    ),
-                    child: Align(
-                      alignment: Alignment.centerLeft,
-                      child: SizedBox(
-                        width: 300,
-                        child: DropdownButtonFormField<ExportDateRange>(
-                          value: _exportPeriodGroupValue,
-                          icon: const Icon(Icons.expand_more),
-                          iconSize: 24,
-                          elevation: 16,
-                          borderRadius: BorderRadius.circular(12),
-                          isExpanded: true,
-                          dropdownColor: ThemeService().isDarkTheme()
-                              ? AppColors.dark
-                              : AppColors.light,
-                          decoration: InputDecoration(
-                            enabledBorder: dropdownBorder,
-                            focusedBorder: dropdownBorder,
-                            border: dropdownBorder,
-                            filled: true,
-                            fillColor: ThemeService().isDarkTheme()
-                                ? AppColors.dark
-                                : AppColors.light,
-                          ),
-                          onChanged: (newValue) async {
-                            setState(() {
-                              _exportPeriodGroupValue = newValue!;
-                            });
-                            if (newValue == ExportDateRange.custom) {
-                              // await selectVideosFromStorage();
-                              Get.toNamed(Routes.SELECT_VIDEOS_FROM_STORAGE);
-                            }
-                          },
-                          items: _exportPeriods
-                              .map<DropdownMenuItem<ExportDateRange>>(
-                            (ExportDateRange value) {
-                              return DropdownMenuItem<ExportDateRange>(
-                                value: value,
-                                child: Text(value.localizationLabel.tr),
-                              );
-                            },
-                          ).toList(),
+                      child: Text(
+                        'dateRange'.tr,
+                        style: TextStyle(
+                          fontSize: MediaQuery.of(context).size.height * 0.025,
                         ),
                       ),
                     ),
-                  )
-                ],
-              ),
+                    Padding(
+                      padding: EdgeInsets.only(
+                        left: MediaQuery.of(context).size.height * 0.025,
+                      ),
+                      child: Align(
+                        alignment: Alignment.centerLeft,
+                        child: SizedBox(
+                          width: 300,
+                          child: DropdownButtonFormField<ExportDateRange>(
+                            value: _exportPeriodGroupValue,
+                            icon: const Icon(Icons.expand_more),
+                            iconSize: 24,
+                            elevation: 16,
+                            borderRadius: BorderRadius.circular(12),
+                            isExpanded: true,
+                            dropdownColor: ThemeService().isDarkTheme()
+                                ? AppColors.dark
+                                : AppColors.light,
+                            decoration: InputDecoration(
+                              enabledBorder: dropdownBorder,
+                              focusedBorder: dropdownBorder,
+                              border: dropdownBorder,
+                              filled: true,
+                              fillColor: ThemeService().isDarkTheme()
+                                  ? AppColors.dark
+                                  : AppColors.light,
+                            ),
+                            onChanged: (newValue) async {
+                              setState(() {
+                                _exportPeriodGroupValue = newValue!;
+                              });
+                              if (newValue == ExportDateRange.custom) {
+                                // await selectVideosFromStorage();
+                                Get.toNamed(Routes.SELECT_VIDEOS_FROM_STORAGE);
+                              }
+                            },
+                            items: _exportPeriods
+                                .map<DropdownMenuItem<ExportDateRange>>(
+                              (ExportDateRange value) {
+                                return DropdownMenuItem<ExportDateRange>(
+                                  value: value,
+                                  child: Text(value.localizationLabel.tr),
+                                );
+                              },
+                            ).toList(),
+                          ),
+                        ),
+                      ),
+                    )
+                  ],
+                ),
 
-              SizedBox(height: MediaQuery.of(context).size.height * 0.025),
+                SizedBox(height: MediaQuery.of(context).size.height * 0.025),
 
-              // Orientation
-              // Column(
-              //   crossAxisAlignment: CrossAxisAlignment.start,
-              //   mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              //   children: [
-              //     Padding(
-              //       padding: EdgeInsets.only(
-              //         left: MediaQuery.of(context).size.width * 0.04,
-              //         bottom: MediaQuery.of(context).size.height * 0.01,
-              //       ),
-              //       child: Text(
-              //         'orientation'.tr,
-              //         style: TextStyle(
-              //           fontSize: MediaQuery.of(context).size.height * 0.025,
-              //         ),
-              //       ),
-              //     ),
-              //     Padding(
-              //       padding: EdgeInsets.only(
-              //         left: MediaQuery.of(context).size.height * 0.025,
-              //       ),
-              //       child: Align(
-              //         alignment: Alignment.centerLeft,
-              //         child: SizedBox(
-              //           width: 300,
-              //           child: DropdownButtonFormField<ExportOrientation>(
-              //             value: _orientationDefaultValue,
-              //             icon: const Icon(Icons.expand_more),
-              //             iconSize: 24,
-              //             elevation: 16,
-              //             borderRadius: BorderRadius.circular(12),
-              //             isExpanded: true,
-              //             dropdownColor:
-              //                 ThemeService().isDarkTheme() ? AppColors.dark : AppColors.light,
-              //             decoration: InputDecoration(
-              //               enabledBorder: dropdownBorder,
-              //               focusedBorder: dropdownBorder,
-              //               border: dropdownBorder,
-              //               filled: true,
-              //               fillColor: ThemeService().isDarkTheme()
-              //                   ? AppColors.dark
-              //                   : AppColors.light,
-              //             ),
-              //             onChanged: (newValue) {
-              //               setState(() {
-              //                 _orientationDefaultValue = newValue!;
-              //               });
-              //             },
-              //             items: _orientationValues.map<DropdownMenuItem<ExportOrientation>>(
-              //               (ExportOrientation value) {
-              //                 return DropdownMenuItem<ExportOrientation>(
-              //                   value: value,
-              //                   child: Text(value.localizationLabel.tr),
-              //                 );
-              //               },
-              //             ).toList(),
-              //           ),
-              //         ),
-              //       ),
-              //     ),
-              //   ],
-              // ),
-              const Spacer(),
-              if (_exportPeriodGroupValue != ExportDateRange.custom)
-                Text(
-                  '${'clipsFound'.tr}: ${getClipsFound()}',
-                  style: TextStyle(
-                    fontSize: MediaQuery.of(context).size.width * 0.060,
+                // Orientation
+                // Column(
+                //   crossAxisAlignment: CrossAxisAlignment.start,
+                //   mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                //   children: [
+                //     Padding(
+                //       padding: EdgeInsets.only(
+                //         left: MediaQuery.of(context).size.width * 0.04,
+                //         bottom: MediaQuery.of(context).size.height * 0.01,
+                //       ),
+                //       child: Text(
+                //         'orientation'.tr,
+                //         style: TextStyle(
+                //           fontSize: MediaQuery.of(context).size.height * 0.025,
+                //         ),
+                //       ),
+                //     ),
+                //     Padding(
+                //       padding: EdgeInsets.only(
+                //         left: MediaQuery.of(context).size.height * 0.025,
+                //       ),
+                //       child: Align(
+                //         alignment: Alignment.centerLeft,
+                //         child: SizedBox(
+                //           width: 300,
+                //           child: DropdownButtonFormField<ExportOrientation>(
+                //             value: _orientationDefaultValue,
+                //             icon: const Icon(Icons.expand_more),
+                //             iconSize: 24,
+                //             elevation: 16,
+                //             borderRadius: BorderRadius.circular(12),
+                //             isExpanded: true,
+                //             dropdownColor:
+                //                 ThemeService().isDarkTheme() ? AppColors.dark : AppColors.light,
+                //             decoration: InputDecoration(
+                //               enabledBorder: dropdownBorder,
+                //               focusedBorder: dropdownBorder,
+                //               border: dropdownBorder,
+                //               filled: true,
+                //               fillColor: ThemeService().isDarkTheme()
+                //                   ? AppColors.dark
+                //                   : AppColors.light,
+                //             ),
+                //             onChanged: (newValue) {
+                //               setState(() {
+                //                 _orientationDefaultValue = newValue!;
+                //               });
+                //             },
+                //             items: _orientationValues.map<DropdownMenuItem<ExportOrientation>>(
+                //               (ExportOrientation value) {
+                //                 return DropdownMenuItem<ExportOrientation>(
+                //                   value: value,
+                //                   child: Text(value.localizationLabel.tr),
+                //                 );
+                //               },
+                //             ).toList(),
+                //           ),
+                //         ),
+                //       ),
+                //     ),
+                //   ],
+                // ),
+                const Spacer(),
+                if (_exportPeriodGroupValue != ExportDateRange.custom)
+                  Text(
+                    '${'clipsFound'.tr}: ${getClipsFound()}',
+                    style: TextStyle(
+                      fontSize: MediaQuery.of(context).size.width * 0.060,
+                    ),
                   ),
+                const Spacer(),
+                Text(
+                  'tapBelowToGenerate'.tr,
+                  style: TextStyle(
+                    fontSize: MediaQuery.of(context).size.width * 0.045,
+                  ),
+                  textAlign: TextAlign.center,
                 ),
-              const Spacer(),
-              Text(
-                'tapBelowToGenerate'.tr,
-                style: TextStyle(
-                  fontSize: MediaQuery.of(context).size.width * 0.045,
+                const SizedBox(height: 20.0),
+                CreateMovieButton(
+                  selectedExportDateRange: _exportPeriodGroupValue,
+                  // selectedOrientation: _orientationDefaultValue,
                 ),
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: 20.0),
-              CreateMovieButton(
-                selectedExportDateRange: _exportPeriodGroupValue,
-                // selectedOrientation: _orientationDefaultValue,
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 
 class Constants {
+  // Added in video metadata so we can differentiate from previous versions
+  static const String artist = 'One Second Diary - v1.5';
   static const String donationUrl = 'https://www.buymeacoffee.com/kylekun';
   static const String backupTutorialUrl = 'https://youtu.be/DTvKktkQ4MU';
   static const String email = 'mailto:kylekundev@gmail.com';

--- a/lib/utils/storage_utils.dart
+++ b/lib/utils/storage_utils.dart
@@ -114,13 +114,13 @@ class StorageUtils {
   }
 
   /// Rename file
-  static bool renameFile(String oldPath, String newPath) {
-    try {
-      io.File(oldPath).renameSync(newPath);
-      return true;
-    } catch (e) {
-      debugPrint(e.toString());
-      return false;
+  static void renameFile(String oldPath, String newPath) {
+    if (checkFileExists(oldPath)) {
+      try {
+        io.File(oldPath).renameSync(newPath);
+      } catch (e) {
+        debugPrint(e.toString());
+      }
     }
   }
 
@@ -131,6 +131,8 @@ class StorageUtils {
 
   /// Delete old video if user is editing daily entry
   static void deleteFile(String filePath) {
-    io.File(filePath).deleteSync(recursive: true);
+    if (checkFileExists(filePath)) {
+      io.File(filePath).deleteSync(recursive: true);
+    }
   }
 }

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -93,19 +93,18 @@ class Utils {
   }
 
   /// Write txt used by ffmpeg to concatenate videos when generating movie
-  static Future<String> writeTxt(List<String> files, bool isCustom) async {
+  static Future<String> writeTxt(List<String> files) async {
     final io.Directory directory = await getApplicationDocumentsDirectory();
     final String txtPath = '${directory.path}/videos.txt';
     final String appPath = SharedPrefsUtil.getString('appPath');
 
     // Delete old txt files
-    if (StorageUtils.checkFileExists(txtPath)) StorageUtils.deleteFile(txtPath);
+    StorageUtils.deleteFile(txtPath);
 
     final io.File file = io.File(txtPath);
 
     for (int i = 0; i < files.length; i++) {
-      // Do not add app folder path if custom videos are being used
-      final String filePath = isCustom ? files[i] : appPath + files[i];
+      final String filePath = appPath + files[i];
 
       // Add file and a new line at the end
       String ffString = "file '$filePath'\r\n";
@@ -120,13 +119,35 @@ class Utils {
     return txtPath;
   }
 
+  /// Write dummy m4a file used by ffmpeg to add audio to the a video
+  // static Future<String> writeM4a() async {
+  //   final io.Directory directory = await getApplicationDocumentsDirectory();
+  //   final String m4aPath = '${directory.path}/dummy.m4a';
+
+  //   // Check if file exists and end it here if so
+  //   // if (StorageUtils.checkFileExists(m4aPath)) return m4aPath;
+
+  //   // ffmpeg command to create m4a file with 48000Hz sample rate
+
+  //   try {
+  //     await executeFFmpeg(
+  //       '-f lavfi -i anullsrc=cl=mono -t 1 $m4aPath -y',
+  //     );
+  //     debugPrint('Dummy m4a file created');
+  //   } catch (e) {
+  //     print(e);
+  //   }
+
+  //   return m4aPath;
+  // }
+
   /// Write srt file used by ffmpeg to add subtitles to the movie
   static Future<String> writeSrt(String text, int videoDuration) async {
     final io.Directory directory = await getApplicationDocumentsDirectory();
     final String srtPath = '${directory.path}/subtitles.srt';
 
     // Delete old srt files
-    if (StorageUtils.checkFileExists(srtPath)) StorageUtils.deleteFile(srtPath);
+    StorageUtils.deleteFile(srtPath);
 
     final io.File file = io.File(srtPath);
 
@@ -171,7 +192,7 @@ class Utils {
     // Getting video names
     for (int i = 0; i < files.length; i++) {
       final String filePath = files[i].path;
-      if (filePath.contains('.mp4')) {
+      if (filePath.contains('.mp4') && !filePath.contains('temp')) {
         if (fullPath) {
           mp4Files.add(filePath);
         } else {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -846,6 +846,41 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.5.3"
+  wakelock:
+    dependency: "direct main"
+    description:
+      name: wakelock
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.2"
+  wakelock_macos:
+    dependency: transitive
+    description:
+      name: wakelock_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.0"
+  wakelock_platform_interface:
+    dependency: transitive
+    description:
+      name: wakelock_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.0"
+  wakelock_web:
+    dependency: transitive
+    description:
+      name: wakelock_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.0"
+  wakelock_windows:
+    dependency: transitive
+    description:
+      name: wakelock_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.1"
   win32:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
   url_launcher: ^6.1.7
   video_player: ^2.4.9
   video_thumbnail: ^0.5.3
+  wakelock: ^0.6.2
 #logger:
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Welp this does a lot of stuff.

In short, we filter videos with `artist` in `metadata`, to check if we will need to add subtitles and audio streams, since past recorded videos didn't have it. This is needed because `concat` fails otherwise. If the streams are not found, they are added with several params that, well, are there for a reason lol. 

This PR also fixes an issue with recording when testing on emulator, forcing `aac` audio to be used.

@daoxve if you can test to confirm it works over there too, much appreciated!

