### PR TITLE
Option for using persistent notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-## v1.5.3 - 09/2023
+## v1.5.3 - 10/2023
+- Added option to receive persistent notifications
 - Added option to change calendar days color for colorblind users
 - Added option to disable date filter in experimental file picker
 - Added reverse filter order button in experimental file picker

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,6 +7,7 @@
 - Bagas Wastu (@bagaswastu)
 - Harry Schiller (@waitingwittykitty)
 - David Coker (@daoxve)
+- Adrasteon (@AdrasteonDev)
 
 ## Testing & Feedback
 - Augusto Vesco

--- a/lib/bindings/initial_binding.dart
+++ b/lib/bindings/initial_binding.dart
@@ -1,10 +1,15 @@
 import 'package:get/get.dart';
 
 import '../controllers/lang_controller.dart';
+import '../utils/notification_service.dart';
 
 class InitialBinding extends Bindings {
   @override
   void dependencies() {
     Get.put<LanguageController>(LanguageController());
+    Get.put<NotificationService>(
+      NotificationService(),
+      permanent: true,
+    );
   }
 }

--- a/lib/controllers/daily_entry_controller.dart
+++ b/lib/controllers/daily_entry_controller.dart
@@ -1,6 +1,7 @@
 import 'package:get/get.dart';
 
 import '../utils/date_format_utils.dart';
+import '../utils/notification_service.dart';
 import '../utils/shared_preferences_util.dart';
 
 class DailyEntryController extends GetxController {
@@ -11,11 +12,15 @@ class DailyEntryController extends GetxController {
   }
 
   final dailyEntry = SharedPrefsUtil.getBool('dailyEntry')?.obs ?? false.obs;
+  final NotificationService notificationService = Get.find();
 
   void updateDaily({bool value = true}) {
     SharedPrefsUtil.putBool('dailyEntry', value);
     dailyEntry.value = value;
     dailyEntry.refresh();
+
+    // Remove the existing notification and schedule it again
+    notificationService.rescheduleNotification(DateTime.now());
   }
 
   void _checkTodayEntry() {

--- a/lib/controllers/daily_entry_controller.dart
+++ b/lib/controllers/daily_entry_controller.dart
@@ -33,5 +33,9 @@ class DailyEntryController extends GetxController {
       dailyEntry.value = false;
       dailyEntry.refresh();
     }
+
+    // Remove the existing notification and schedule it again if there is a daily entry
+    if(dailyEntry.value)
+      notificationService.rescheduleNotification(DateTime.now());
   }
 }

--- a/lib/lang/en.dart
+++ b/lib/lang/en.dart
@@ -62,6 +62,7 @@ const Map<String, String> en = {
   'notifications': 'Notifications',
   'enableNotifications': 'Enable Notifications',
   'scheduleTime': 'Schedule Time',
+  'usePersistentNotifications': 'Persistent notifications',
   'test': 'Test',
   'notificationTitle': 'Heyy!',
   'notificationBody': 'Do not forget to record 1 second of your day 👀',

--- a/lib/lang/fr.dart
+++ b/lib/lang/fr.dart
@@ -62,6 +62,7 @@ const Map<String, String> fr = {
   'notifications': 'Notifications',
   'enableNotifications': 'Activer les notifications',
   'scheduleTime': 'Horaire',
+  'usePersistentNotifications': 'Notifications persistantes',
   'test': 'Test',
   'notificationTitle': 'Hé !',
   'notificationBody': "N'oubliez pas d'enregistrer une seconde de votre journée. 👀",

--- a/lib/pages/home/notification/widgets/switch_notifications.dart
+++ b/lib/pages/home/notification/widgets/switch_notifications.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
+import '../../../../controllers/daily_entry_controller.dart';
 import '../../../../routes/app_pages.dart';
 import '../../../../utils/constants.dart';
 import '../../../../utils/notification_service.dart';
@@ -17,7 +18,7 @@ class _SwitchNotificationsComponentState
   late bool isNotificationSwitchToggled;
   TimeOfDay scheduledTimeOfDay = const TimeOfDay(hour: 20, minute: 00);
   late bool isPersistentSwitchToggled;
-  NotificationService notificationService = NotificationService();
+  final NotificationService notificationService = Get.find();
 
   @override
   void initState() {
@@ -56,9 +57,12 @@ class _SwitchNotificationsComponentState
                   onChanged: (value) async {
                     if (value) {
                       await notificationService.turnOnNotifications();
+
                       await notificationService.scheduleNotification(
                           scheduledTimeOfDay.hour,
-                          scheduledTimeOfDay.minute);
+                          scheduledTimeOfDay.minute,
+                          DateTime.now()
+                      );
                     } else {
                       await notificationService.turnOffNotifications();
                     }
@@ -145,7 +149,9 @@ class _SwitchNotificationsComponentState
 
             await notificationService.scheduleNotification(
                 scheduledTimeOfDay.hour,
-                scheduledTimeOfDay.minute);
+                scheduledTimeOfDay.minute,
+                DateTime.now()
+            );
           },
           child: Container(
             padding:
@@ -187,7 +193,7 @@ class _SwitchNotificationsComponentState
                   if (value) {
                     notificationService.activatePersistentNotifications();
                   } else {
-                    notificationService.unactivatePersistentNotifications();
+                    notificationService.deactivatePersistentNotifications();
                   }
 
                   /// Schedule notification if switch in ON
@@ -201,7 +207,9 @@ class _SwitchNotificationsComponentState
                   if(isNotificationSwitchToggled){
                     await notificationService.scheduleNotification(
                         scheduledTimeOfDay.hour,
-                        scheduledTimeOfDay.minute);
+                        scheduledTimeOfDay.minute,
+                        DateTime.now()
+                    );
                   }
 
                   /// Update switch value

--- a/lib/utils/notification_service.dart
+++ b/lib/utils/notification_service.dart
@@ -24,7 +24,8 @@ class NotificationService {
         'channel id',
         'channel name',
         channelDescription: 'channel description',
-        ongoing: false
+        ongoing: false,
+        autoCancel: true
     ),
   );
   final NotificationDetails _platformPersistentNotificationDetails = const NotificationDetails(
@@ -32,7 +33,8 @@ class NotificationService {
         'channel id',
         'channel name',
         channelDescription: 'channel description',
-        ongoing: true
+        ongoing: true,
+        autoCancel: false
     ),
   );
 
@@ -118,7 +120,7 @@ class NotificationService {
     _switchPersistentNotification();
   }
 
-  Future<void> unactivatePersistentNotifications() async {
+  Future<void> deactivatePersistentNotifications() async {
     Utils.logInfo(
       '[NOTIFICATIONS] - Persistent notifications were disabled',
     );
@@ -128,15 +130,14 @@ class NotificationService {
     _switchPersistentNotification();
   }
 
-  Future<void> scheduleNotification(int hour, int minute) async {
+  Future<void> scheduleNotification(int hour, int minute, DateTime day) async {
     _flutterLocalNotificationsPlugin.cancelAll();
-    final now = DateTime.now();
 
     // sets the scheduled time in DateTime format
     final String setTime = DateTime(
-      now.year,
-      now.month,
-      now.day,
+      day.year,
+      day.month,
+      day.day,
       hour,
       minute,
     ).toString();
@@ -156,6 +157,11 @@ class NotificationService {
       // Allow notification to be shown daily
       matchDateTimeComponents: DateTimeComponents.time,
     );
+  }
+
+  Future<void> rescheduleNotification(DateTime day) async {
+    final TimeOfDay timeOfDay = getScheduledTime();
+    await scheduleNotification(timeOfDay.hour, timeOfDay.minute, day);
   }
 
   Future<void> showTestNotification() async {

--- a/lib/utils/notification_service.dart
+++ b/lib/utils/notification_service.dart
@@ -1,24 +1,179 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:fluttertoast/fluttertoast.dart';
+import 'package:get/get.dart';
+import 'package:permission_handler/permission_handler.dart';
+import 'package:timezone/data/latest.dart' as tz;
+import 'package:timezone/timezone.dart' as tz;
+
+import 'constants.dart';
 import 'shared_preferences_util.dart';
+import 'utils.dart';
 
 class NotificationService {
-  final _key = 'activatedNotification';
-  final _persistentKey = 'activatedNotification';
+  final _notificationKey = 'activatedNotification';
+  final _persistentKey = 'persistentNotification';
+  final _hourKey = 'scheduledTimeHour';
+  final _minuteKey = 'scheduledTimeMinute';
+  final int _notificationId = 1;
+  final _flutterLocalNotificationsPlugin = FlutterLocalNotificationsPlugin();
 
-  // Notification is deactivated by default
-  bool isNotificationActivated() => SharedPrefsUtil.getBool(_key) ?? false;
-  bool isPersistentNotificationActivated() => SharedPrefsUtil.getBool(_persistentKey) ?? false;
+  late NotificationDetails _platformNotificationDetails;
+  final NotificationDetails _platformNonPersistentNotificationDetails = const NotificationDetails(
+    android: AndroidNotificationDetails(
+        'channel id',
+        'channel name',
+        channelDescription: 'channel description',
+        ongoing: false
+    ),
+  );
+  final NotificationDetails _platformPersistentNotificationDetails = const NotificationDetails(
+    android: AndroidNotificationDetails(
+        'channel id',
+        'channel name',
+        channelDescription: 'channel description',
+        ongoing: true
+    ),
+  );
 
-  Future<bool> _saveNotification(bool isActivated) =>
-      SharedPrefsUtil.putBool(_key, isActivated);
+  NotificationService(){
+    if(isPersistentNotificationActivated())
+      _platformNotificationDetails = _platformPersistentNotificationDetails;
+    else
+      _platformNotificationDetails = _platformNonPersistentNotificationDetails;
 
-  Future<bool> _savePersistentNotification(bool isActivated) =>
-      SharedPrefsUtil.putBool(_persistentKey, isActivated);
+    /// Initializing notification settings
+    tz.initializeTimeZones();
 
-  void switchNotification() {
-    _saveNotification(!isNotificationActivated());
+    const AndroidInitializationSettings androidInitializationSettings =
+    AndroidInitializationSettings('@mipmap/ic_launcher');
+
+    const DarwinInitializationSettings iosInitializationSettings =
+    DarwinInitializationSettings();
+
+    const InitializationSettings initializationSettings =
+    InitializationSettings(
+      android: androidInitializationSettings,
+      iOS: iosInitializationSettings,
+    );
+
+    _flutterLocalNotificationsPlugin.initialize(initializationSettings);
   }
 
-  void switchPersistentNotification() {
-    _savePersistentNotification(!isPersistentNotificationActivated());
+  // Notification is deactivated by default
+  bool isNotificationActivated() => SharedPrefsUtil.getBool(_notificationKey) ?? false;
+  bool isPersistentNotificationActivated() => SharedPrefsUtil.getBool(_persistentKey) ?? false;
+
+  // Checks for the scheduled time and sets it to a value in shared prefs
+  TimeOfDay getScheduledTime() {
+    final int hour = SharedPrefsUtil.getInt(_hourKey) ?? 20;
+    final int minute = SharedPrefsUtil.getInt(_minuteKey) ?? 00;
+    return TimeOfDay(hour: hour, minute: minute);
+  }
+
+  void _switchNotification() {
+    SharedPrefsUtil.putBool(_notificationKey, !isNotificationActivated());
+  }
+
+  void _switchPersistentNotification() {
+    SharedPrefsUtil.putBool(_persistentKey, !isPersistentNotificationActivated());
+  }
+
+  void setScheduledTime(int hour, int minute) {
+    SharedPrefsUtil.putInt(_hourKey, hour);
+    SharedPrefsUtil.putInt(_minuteKey, minute);
+  }
+
+  Future<void> turnOnNotifications() async {
+    Utils.logInfo(
+      '[NOTIFICATIONS] - Notifications were enabled',
+    );
+
+    /// Schedule notification if switch in ON
+    await Utils.requestPermission(Permission.notification);
+
+    /// Save notification on SharedPrefs
+    _switchNotification();
+  }
+
+  Future<void> turnOffNotifications() async {
+    Utils.logInfo(
+      '[NOTIFICATIONS] - Notifications were disabled',
+    );
+
+    /// Cancel notification if switch is OFF
+    _flutterLocalNotificationsPlugin.cancelAll();
+
+    /// Save notification on SharedPrefs
+    _switchNotification();
+  }
+
+  Future<void> activatePersistentNotifications() async {
+    Utils.logInfo(
+      '[NOTIFICATIONS] - Persistent notifications were enabled',
+    );
+    _platformNotificationDetails = _platformPersistentNotificationDetails;
+
+    /// Save notification on SharedPrefs
+    _switchPersistentNotification();
+  }
+
+  Future<void> unactivatePersistentNotifications() async {
+    Utils.logInfo(
+      '[NOTIFICATIONS] - Persistent notifications were disabled',
+    );
+    _platformNotificationDetails = _platformNonPersistentNotificationDetails;
+
+    /// Save notification on SharedPrefs
+    _switchPersistentNotification();
+  }
+
+  Future<void> scheduleNotification(int hour, int minute) async {
+    _flutterLocalNotificationsPlugin.cancelAll();
+    final now = DateTime.now();
+
+    // sets the scheduled time in DateTime format
+    final String setTime = DateTime(
+      now.year,
+      now.month,
+      now.day,
+      hour,
+      minute,
+    ).toString();
+
+    Utils.logInfo('[NOTIFICATIONS] - Scheduled with setTime=$setTime');
+
+    /// Schedule notification
+    await _flutterLocalNotificationsPlugin.zonedSchedule(
+      _notificationId,
+      'notificationTitle'.tr,
+      'notificationBody'.tr,
+      tz.TZDateTime.parse(tz.local, setTime),
+      _platformNotificationDetails,
+      uiLocalNotificationDateInterpretation:
+      UILocalNotificationDateInterpretation.absoluteTime,
+      androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
+      // Allow notification to be shown daily
+      matchDateTimeComponents: DateTimeComponents.time,
+    );
+  }
+
+  Future<void> showTestNotification() async {
+    await _flutterLocalNotificationsPlugin.show(
+      _notificationId,
+      'test'.tr,
+      'test'.tr,
+      _platformNotificationDetails,
+    );
+
+    // Feedback to the user that the notification was called
+    await Fluttertoast.showToast(
+      msg: 'done'.tr,
+      toastLength: Toast.LENGTH_SHORT,
+      gravity: ToastGravity.CENTER,
+      backgroundColor: AppColors.dark,
+      textColor: Colors.white,
+      fontSize: 16.0,
+    );
   }
 }

--- a/lib/utils/notification_service.dart
+++ b/lib/utils/notification_service.dart
@@ -2,14 +2,23 @@ import 'shared_preferences_util.dart';
 
 class NotificationService {
   final _key = 'activatedNotification';
+  final _persistentKey = 'activatedNotification';
 
   // Notification is deactivated by default
   bool isNotificationActivated() => SharedPrefsUtil.getBool(_key) ?? false;
+  bool isPersistentNotificationActivated() => SharedPrefsUtil.getBool(_persistentKey) ?? false;
 
   Future<bool> _saveNotification(bool isActivated) =>
       SharedPrefsUtil.putBool(_key, isActivated);
 
+  Future<bool> _savePersistentNotification(bool isActivated) =>
+      SharedPrefsUtil.putBool(_persistentKey, isActivated);
+
   void switchNotification() {
     _saveNotification(!isNotificationActivated());
+  }
+
+  void switchPersistentNotification() {
+    _savePersistentNotification(!isPersistentNotificationActivated());
   }
 }


### PR DESCRIPTION
# Description
First of all, thank you for creating One Second Diary ! I use it almost every day and I really like its concept.

The goal of the PR is to add an option for using persistent notifications (see the [related issue](https://github.com/KyleKun/one_second_diary/issues/66)).

I've added the "usePersistentNotifications" key to the English and French translation files. I don't know how to translate it into other languages. You may need to add a commit to add this key to the other translation files.

I had to add code to close the persistent notification and reschedule it when a daily entry is added, as the persistent notification cannot be cancelled by the user. I moved some methods from SwitchNotificationsComponent to NotificationService for this purpose.

For information I initially wanted to reschedule notifications to the next day when an entry is added, to make this case not possible:

- A user schedules a persistent notification at 3 p.m.
- The user records a video at 2pm
- He receives the persistent notification at 3pm even though he has already recorded a video

I wasn't able to prevent this to happen, as the flutter_local_notification package doesn't allow to specify an initial date for "time" notifications. However, I managed to close the notification when the user opens the application if a video has already been recorded for the current day.

## Checklist

Before you create this PR, please confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I have added a description of the change in `CHANGELOG.md`.
- [X] I have added my name in the `CONTRIBUTORS.md` file, if it wasn't already present.
