### PR TITLE
Ignore personal agent tooling config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,9 @@ app.*.symbols
 /android/app/profile
 /android/app/release
 /android/build
+
+# Personal agent tooling config — not meant for the upstream repo
+.agents/
+.antigravitycli/
+AGENTS.md
+docs/agents/


### PR DESCRIPTION
# Description

.agents/, .antigravitycli/, AGENTS.md, and docs/agents/ are local agent harness bootstrap files, not meant to land in the eventual PR back to the upstream fork.