### PR TITLE
Fix profile name validator accepting whitespace-only names

### DIFF
--- a/lib/pages/home/profiles/profiles_page.dart
+++ b/lib/pages/home/profiles/profiles_page.dart
@@ -7,6 +7,7 @@ import '../../../models/profile.dart';
 import '../../../utils/app_paths.dart';
 import '../../../utils/constants.dart';
 import '../../../utils/date_format_utils.dart';
+import '../../../utils/profile_name_validator.dart';
 import '../../../utils/shared_preferences_util.dart';
 import '../../../utils/storage_utils.dart';
 import '../../../utils/theme.dart';
@@ -95,24 +96,23 @@ class _ProfilesPageState extends State<ProfilesPage> {
                     LengthLimitingTextInputFormatter(45),
                   ],
                   validator: (value) {
-                    if (value == null || value.isEmpty) {
-                      return 'profileNameCannotBeEmpty'.tr;
+                    final ProfileNameError? error = ProfileNameValidator.validate(
+                      value ?? '',
+                      existingLabels: profiles.map((profile) => profile.label).toList(),
+                      localizedDefaultLabel: 'default'.tr,
+                    );
+                    switch (error) {
+                      case ProfileNameError.empty:
+                        return 'profileNameCannotBeEmpty'.tr;
+                      case ProfileNameError.invalidCharacters:
+                        return 'profileNameCannotContainSpecialChars'.tr;
+                      case ProfileNameError.reserved:
+                        return 'reservedProfileName'.tr;
+                      case ProfileNameError.duplicate:
+                        return 'profileNameAlreadyExists'.tr;
+                      case null:
+                        return null;
                     }
-                    if (!value.contains(RegExp(r'^[\w\d _-]+$'))) {
-                      return 'profileNameCannotContainSpecialChars'.tr;
-                    }
-
-                    if (value.toLowerCase().trim() == 'default' ||
-                        value.toLowerCase().trim() == 'default'.tr.toLowerCase()) {
-                      return 'reservedProfileName'.tr;
-                    }
-
-                    if (profiles.any(
-                        (profile) => profile.label.toLowerCase() == value.toLowerCase().trim())) {
-                      return 'profileNameAlreadyExists'.tr;
-                    }
-
-                    return null;
                   },
                   decoration: InputDecoration(
                     hintText: 'enterProfileName'.tr,

--- a/lib/utils/profile_name_validator.dart
+++ b/lib/utils/profile_name_validator.dart
@@ -1,0 +1,45 @@
+/// Why a candidate profile name was rejected. The creation dialog owns the
+/// localized copy shown for each; this only owns the decision.
+enum ProfileNameError { empty, invalidCharacters, reserved, duplicate }
+
+class ProfileNameValidator {
+  ProfileNameValidator._();
+
+  /// Validates [rawValue] as a new profile name, or `null` if it's fine.
+  ///
+  /// The emptiness check runs against the trimmed value — a name that's
+  /// only whitespace is empty, not a valid one. Left untrimmed, "   "
+  /// passes this check (it isn't the empty string) and every check below
+  /// it (space is an allowed character) and then collapses to '' at the
+  /// call site's own `.trim()`, which is the exact key this app reserves
+  /// for the Default profile elsewhere (`AppPaths.profileVideos`,
+  /// `StorageUtils`'s per-profile keys) — silently aliasing a "new"
+  /// profile onto Default's storage instead of getting rejected.
+  ///
+  /// Every other check runs against [rawValue] as typed, untrimmed —
+  /// deliberately, so this only changes the one broken case rather than
+  /// also loosening the allowed-characters check (e.g. a trailing tab
+  /// should still be rejected as an invalid character, not silently
+  /// dropped and accepted).
+  static ProfileNameError? validate(
+    String rawValue, {
+    required List<String> existingLabels,
+    required String localizedDefaultLabel,
+  }) {
+    if (rawValue.trim().isEmpty) return ProfileNameError.empty;
+    if (!rawValue.contains(RegExp(r'^[\w\d _-]+$'))) {
+      return ProfileNameError.invalidCharacters;
+    }
+
+    final String lowerValue = rawValue.toLowerCase().trim();
+    if (lowerValue == 'default' || lowerValue == localizedDefaultLabel.toLowerCase()) {
+      return ProfileNameError.reserved;
+    }
+
+    if (existingLabels.any((label) => label.toLowerCase() == lowerValue)) {
+      return ProfileNameError.duplicate;
+    }
+
+    return null;
+  }
+}

--- a/test/utils/profile_name_validator_test.dart
+++ b/test/utils/profile_name_validator_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:one_second_diary/utils/profile_name_validator.dart';
+
+void main() {
+  group('validate', () {
+    test('accepts a normal name with no existing profiles', () {
+      expect(
+        ProfileNameValidator.validate('Bob', existingLabels: const [], localizedDefaultLabel: 'Default'),
+        isNull,
+      );
+    });
+
+    test('rejects an empty name', () {
+      expect(
+        ProfileNameValidator.validate('', existingLabels: const [], localizedDefaultLabel: 'Default'),
+        ProfileNameError.empty,
+      );
+    });
+
+    test('rejects a whitespace-only name — trimming it must not silently produce the '
+        'empty string this app reserves for the Default profile', () {
+      expect(
+        ProfileNameValidator.validate('   ', existingLabels: const [], localizedDefaultLabel: 'Default'),
+        ProfileNameError.empty,
+      );
+    });
+
+    test('rejects special characters', () {
+      expect(
+        ProfileNameValidator.validate('Bob/Alice', existingLabels: const [], localizedDefaultLabel: 'Default'),
+        ProfileNameError.invalidCharacters,
+      );
+    });
+
+    test('rejects a trailing tab as an invalid character rather than trimming it away', () {
+      // Only the emptiness check trims — every other check runs on the
+      // value as typed, so this must stay rejected exactly like it was
+      // before the whitespace-collapses-to-empty fix, not silently
+      // cleaned up and accepted as "Bob".
+      expect(
+        ProfileNameValidator.validate('Bob\t', existingLabels: const [], localizedDefaultLabel: 'Default'),
+        ProfileNameError.invalidCharacters,
+      );
+    });
+
+    test('allows word characters, digits, spaces, underscores and hyphens', () {
+      expect(
+        ProfileNameValidator.validate('Bob_Trip-2024 2', existingLabels: const [], localizedDefaultLabel: 'Default'),
+        isNull,
+      );
+    });
+
+    test('rejects the reserved English "default" name, case-insensitively', () {
+      expect(
+        ProfileNameValidator.validate('DEFAULT', existingLabels: const [], localizedDefaultLabel: 'Default'),
+        ProfileNameError.reserved,
+      );
+    });
+
+    test('rejects the localized default label too', () {
+      expect(
+        ProfileNameValidator.validate('Estandar',
+            existingLabels: const [], localizedDefaultLabel: 'Estandar'),
+        ProfileNameError.reserved,
+      );
+    });
+
+    test('rejects a name that collides with an existing profile, case-insensitively', () {
+      expect(
+        ProfileNameValidator.validate('bob',
+            existingLabels: const ['Bob'], localizedDefaultLabel: 'Default'),
+        ProfileNameError.duplicate,
+      );
+    });
+
+    test('ignores leading/trailing whitespace when checking for duplicates', () {
+      expect(
+        ProfileNameValidator.validate('  Bob  ',
+            existingLabels: const ['Bob'], localizedDefaultLabel: 'Default'),
+        ProfileNameError.duplicate,
+      );
+    });
+  });
+}


### PR DESCRIPTION
# Description

The creation dialog's validator checked value.isEmpty before trimming, so a whitespace-only name like "   " passed every check: not empty as a raw string, matches the allowed-characters regex (space is allowed), and trims to "" which isn't 'default' or an existing label. On confirm, _profileNameController.text.trim() then collapsed it to "" — the exact sentinel this app reserves elsewhere for the Default profile's storage (AppPaths.profileVideos(''), StorageUtils's per-profile SharedPreferences keys). A user typing a blank-looking name could silently create a profile aliased onto Default's own storage instead of being rejected.

Noticed this was an issue while working on portrait/vertical video feature and decided to fix as a standalone PR.
